### PR TITLE
Add null check for nullable orientation in neighborChanged

### DIFF
--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/block/InventoryCableBlock.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/block/InventoryCableBlock.java
@@ -34,6 +34,7 @@ import com.mojang.serialization.MapCodec;
 import com.tom.storagemod.client.ClientUtil;
 import com.tom.storagemod.inventory.InventoryCableNetwork;
 import com.tom.storagemod.util.BlockFace;
+import org.jetbrains.annotations.Nullable;
 
 public class InventoryCableBlock extends PipeBlock implements SimpleWaterloggedBlock, IInventoryCable, NeoForgeBlock {
 	public static final BooleanProperty UP = BlockStateProperties.UP;
@@ -169,13 +170,15 @@ public class InventoryCableBlock extends PipeBlock implements SimpleWaterloggedB
 
 	@Override
 	protected void neighborChanged(BlockState blockState, Level level, BlockPos blockPos, Block block,
-			Orientation orientation, boolean bl) {
+								   @Nullable Orientation orientation, boolean bl) {
 		super.neighborChanged(blockState, level, blockPos, block, orientation, bl);
 		if (!level.isClientSide) {
 			InventoryCableNetwork n = InventoryCableNetwork.getNetwork(level);
 			n.markNodeInvalid(blockPos);
-			for (var d : orientation.getDirections()) {
-				n.markNodeInvalid(blockPos.relative(d));
+			if (orientation != null) {
+				for (var d : orientation.getDirections()) {
+					n.markNodeInvalid(blockPos.relative(d));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This adds a null check for the nullable orientation parameter. It also adds the nullable annotation to the parameter.

This fixes this crash report: https://mclo.gs/36a88Js (and #497)