### PR TITLE
Fix filing cabinets not opening on Fabric

### DIFF
--- a/Fabric/src/main/java/com/tom/storagemod/StorageModClient.java
+++ b/Fabric/src/main/java/com/tom/storagemod/StorageModClient.java
@@ -39,6 +39,7 @@ import com.tom.storagemod.network.DataPacket;
 import com.tom.storagemod.network.NetworkHandler;
 import com.tom.storagemod.platform.GameObject;
 import com.tom.storagemod.screen.CraftingTerminalScreen;
+import com.tom.storagemod.screen.FilingCabinetScreen;
 import com.tom.storagemod.screen.InventoryConfiguratorScreen;
 import com.tom.storagemod.screen.InventoryLinkScreen;
 import com.tom.storagemod.screen.ItemFilterScreen;
@@ -61,6 +62,7 @@ public class StorageModClient implements ClientModInitializer {
 		MenuScreens.register(Content.inventoryLink.get(), InventoryLinkScreen::new);
 		MenuScreens.register(Content.itemFilterMenu.get(), ItemFilterScreen::new);
 		MenuScreens.register(Content.tagItemFilterMenu.get(), TagItemFilterScreen::new);
+		MenuScreens.register(Content.filingCabinetMenu.get(), FilingCabinetScreen::new);
 
 		BlockRenderLayerMap.INSTANCE.putBlock(Content.paintedTrim.get(), RenderType.translucent());
 		BlockRenderLayerMap.INSTANCE.putBlock(Content.invCableFramed.get(), RenderType.translucent());


### PR DESCRIPTION
Previously right-clicking one would just give a warning in the log:
```
Failed to create screen for menu type: toms_storage:filing_cabinet
```