### PR TITLE
Fixed fr_fr.json in terminal menu translation so that it doesn't go over the search bar

### DIFF
--- a/NeoForge/src/platform-shared/resources/assets/toms_storage/lang/fr_fr.json
+++ b/NeoForge/src/platform-shared/resources/assets/toms_storage/lang/fr_fr.json
@@ -25,8 +25,8 @@
 	
 	"itemGroup.toms_storage.tab": "Tom's Simple Storage",
 	
-	"menu.toms_storage.storage_terminal": "Cons. de stockage",
-	"menu.toms_storage.crafting_terminal": "Cons. de fabrication",
+	"menu.toms_storage.storage_terminal": "Cons. de stoc.",
+	"menu.toms_storage.crafting_terminal": "Cons. de fab.",
 	"menu.toms_storage.level_emitter": "Émetteur de signal",
 	"menu.toms_storage.inventory_connector": "Connecteur d'inventaire",
 	"menu.toms_storage.inventory_configurator": "Configurateur d'inventaire (%s)",


### PR DESCRIPTION
I fixed the fact that in French, the name in the terminals is too long and goes over the search bar, making it impossible to read what you type.

I made the change on the master, but it can be changed for recent versions of the game.