### PR TITLE
Add support for REI again

### DIFF
--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -122,8 +122,8 @@ sourceSets {
 	main {
 		java {
 			srcDir "../NeoForge/src/platform-shared/java"
-			if(!useLib)exclude "com/tom/storagemod/jei/**"
-			/*if(!useLib)*/exclude "com/tom/storagemod/rei/**"
+			if(!useLib) exclude "com/tom/storagemod/jei/**"
+			if(!useLib) exclude "com/tom/storagemod/rei/**"
 			/*if(!useLib)*/exclude "com/tom/storagemod/emi/**"
 			//if(!useLib)exclude "com/tom/storagemod/jade/**"
 			//if(!useLib)exclude "com/tom/storagemod/ModMenu.java"


### PR DESCRIPTION
Fix REI plugin `ClassNotFoundException` on Fabric by uncommenting conditional exclusion

## Description
Fixes #698

This PR fixes a `ClassNotFoundException` that occurs when loading Tom's Storage with RoughlyEnoughItems (REI) on Fabric for Minecraft 1.21.11.

## Problem
The Fabric build configuration in `build.gradle` had a commented-out conditional that was causing REI plugin classes to always be excluded from compilation, presumably because no REI existed for 1.21.11: 

```gradle
/*if(!useLib)*/exclude "com/tom/storagemod/rei/**"
```

This meant that even though `fabric.mod.json` declared the rei_client entrypoint, the actual REIPlugin class was never compiled into the JAR, causing a runtime crash when REI support for 1.21.11 was eventually released.

## Changes
Uncommented the conditional at `Fabric/build.gradle#L126`:

```gradle
if(!useLib) exclude "com/tom/storagemod/rei/**"
```

Now the REI plugin classes are properly included when building with `-DuseLib=true`, matching the pattern used for JEI.

## Testing

- [x] Built with `./gradlew clean build -DuseLib=true`
- [x] Verified REI plugin classes are present in the compiled JAR
- [x] Tested in Minecraft 1.21.11 with REI 21.11.814+fabric (and a bunch of other mods)
- [x] Confirmed no `ClassNotFoundException` occurs