### PR TITLE
Fix PuzzlesLib isHovering collision on snapshot Fabric

### DIFF
--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/screen/AbstractFilteredScreen.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/screen/AbstractFilteredScreen.java
@@ -2,7 +2,6 @@ package com.tom.storagemod.screen;
 
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
-import net.minecraft.world.inventory.Slot;
 
 import com.tom.storagemod.menu.AbstractFilteredMenu;
 
@@ -10,9 +9,5 @@ public abstract class AbstractFilteredScreen<T extends AbstractFilteredMenu> ext
 
 	public AbstractFilteredScreen(T p_97741_, Inventory p_97742_, Component p_97743_) {
 		super(p_97741_, p_97742_, p_97743_);
-	}
-
-	public boolean isHovering(Slot slot, double d, double e) {
-		return this.isHovering(slot.x, slot.y, 16, 16, d, e);
 	}
 }


### PR DESCRIPTION
Fixes #736.

PuzzlesLib makes `AbstractContainerScreen.isHovering(Slot, double, double)` accessible on this line, which causes Tom's Storage's copied helper in `AbstractFilteredScreen` to collide with the now-visible vanilla method during class loading. On 26.x Fabric this shows up as an `IncompatibleClassChangeError` when `StorageModClient` initializes.

This change removes the redundant helper override from `AbstractFilteredScreen`. The screen already inherits the vanilla implementation, so behavior stays the same while avoiding the method collision.

Notes:
- the Fabric module on `snapshot` compiles shared Java sources from `NeoForge/src/platform-shared/java`, so the fix belongs in that shared screen class
- verified with a local Fabric build on `snapshot` using Java 25: `bash ./gradlew build`
- this is the same crash signature reported in #736 / Fuzss/puzzles-lib#189