### PR TITLE
Add repository agent guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,241 @@
+# AGENTS.md
+
+## Repository Overview
+
+Tom's Simple Storage Mod is a Java Minecraft mod that provides storage and crafting terminals, inventory connectors, cables, wireless access, filters, hoppers, and inventory links. The mod ID and resource namespace are `toms_storage`; Java code uses the `com.tom.storagemod` package.
+
+This repository is a collection of independent version/loader projects. It is **not** a Gradle multi-project build. There is no root `build.gradle`, root Gradle wrapper, aggregate test task, or CI workflow. Always choose one target project before editing or running Gradle.
+
+## Project Matrix
+
+| Directory | Loader | Minecraft | Java | Notes |
+| --- | --- | --- | --- | --- |
+| `Toms-Storage-120` | Forge | 1.20.1 | 17 | Primary 1.20.1 Forge line |
+| `Toms-Storage-1202` | NeoForge | 1.20.2 | 17 | Reuses parts of the 1.20.1 source line |
+| `Toms-Storage-1204` | NeoForge | 1.20.4 | 17 | Self-contained shared/platform sources |
+| `Toms-Storage-1206` | NeoForge | 1.20.6 | 21 | Best reference for current NeoForge architecture |
+| `Toms-Storage-Fabric-1.20` | Fabric | 1.20.1 | 17 | Fabric loader implementation |
+| `Toms-Storage-Fabric-1.20.2` | Fabric | 1.20.2 | 17 | Reuses older shared and loader sources |
+| `Toms-Storage-Fabric-1.20.4` | Fabric | 1.20.4 | 17 | Fabric loader implementation |
+| `Toms-Storage-Fabric-1.20.6` | Fabric | 1.20.6 | 21 configured, `--release 17` | Resolve this contradiction before using Java 21 syntax |
+| `Toms-Storage-LexForge-1202` | Forge | 1.20.2 | 17 | Legacy Forge compatibility port |
+| `Toms-Storage-LexForge-1204` | Forge | 1.20.4 | 17 | Legacy Forge compatibility port |
+
+The highest Minecraft version is not necessarily the highest mod release version. Do not infer the target from version numbers alone. State both the Minecraft version and loader in every task, change summary, and validation report.
+
+## Source Composition
+
+Each project composes its `main` source set from several physical layers instead of Gradle subprojects:
+
+- `src/shared/java`: loader-neutral gameplay, blocks, items, menus/screens, terminal synchronization, recipes, and optional recipe-viewer integrations.
+- `src/loader-shared/java`: code shared within a loader family, including entry points, configuration, networking, block entities, storage/capability wrappers, tags, and model hooks.
+- `src/platform-shared/java`: Minecraft-version-specific abstractions that can still be shared across loaders.
+- `src/main/java`: final loader-specific adapters, especially `com.tom.storagemod.platform.Platform` and client container helpers.
+- `src/shared/resources`: common assets and data packs: block states, models, textures, translations, recipes, loot tables, advancements, and tags.
+- `src/loader-shared/resources`: loader-sensitive tags, models, and integration resources.
+- `src/platform-shared/resources`: version-specific common resources when present.
+- `src/main/resources`: loader metadata, `pack.mcmeta`, access transformers, or access wideners.
+
+Treat these as overlay layers. A file's physical location indicates its portability boundary:
+
+1. Put loader-neutral behavior in `shared` when the target source composition supports it.
+2. Put Forge/NeoForge capability code or Fabric transfer/storage code in `loader-shared`.
+3. Put mapped Minecraft API differences in `platform-shared`.
+4. Keep loader-family lifecycle and event wiring in `loader-shared`; reserve `main` for final adapters that differ between composed projects, such as registry and interaction implementations in `Platform`.
+
+Do not import NeoForge APIs into common Fabric-consumed sources or Fabric APIs into Forge-consumed sources. Use `Platform`, `GameObject`, storage wrappers, and existing interfaces at the boundary.
+
+### Important Source-Path Caveat
+
+Several `build.gradle` files reference sibling directories named `TomsStorage-*` and `TomsStorageFabric-*`, while this checkout contains `Toms-Storage-*` and `Toms-Storage-Fabric-*`. This affects all four Fabric projects, both LexForge projects, and `Toms-Storage-1202`. Gradle silently accepts a missing source directory, so a build can omit expected shared code before eventually failing or, in some cases, provide misleading validation. In the checked-in layout, only `Toms-Storage-120`, `Toms-Storage-1204`, and `Toms-Storage-1206` have complete local source composition.
+
+Before trusting one of these builds:
+
+- inspect that project's `sourceSets` block;
+- verify every referenced sibling directory exists in the current checkout/layout;
+- do not rewrite paths or create symlinks as an unrelated cleanup;
+- report a missing shared-source layout as a validation blocker unless the task explicitly includes fixing it.
+
+## Architecture
+
+### Initialization And Registration
+
+`Content.java` is the canonical declaration point for blocks, items, block entities, menus, and, in 1.20.6, persistent data components. Static declarations are wrapped in `GameObject`; `Content.init()` forces initialization.
+
+- NeoForge/Forge discovers `StorageMod` through `@Mod` and then registers lifecycle listeners, configs, networking, content, capabilities, and platform registries.
+- Fabric discovers entry points through `fabric.mod.json`. `StorageMod.onInitialize()` registers common content, Fabric-only painted variants, block entities, payload handlers, config synchronization, lifecycle hooks, and tags.
+- Client initialization is separate in `StorageModClient`: screens, key bindings, render layers, models/colors, and tooltips belong there.
+- JEI, REI, and EMI are independently discovered plugins/entry points. Keep their annotations/interfaces, Fabric metadata entries, and optional source exclusions aligned; do not initialize them unconditionally from `StorageModClient`.
+- `Platform.java` translates shared registration and interaction requests into the selected loader's APIs.
+
+Adding content is not complete when Java compiles. Coordinate the applicable registrations with block states, models, item models, textures, loot tables, recipes, tags, advancements, translations, and loader metadata. Preserve historical dotted registry IDs such as `ts.storage_terminal`; registry IDs are world compatibility contracts.
+
+### Storage Network Flow
+
+The central runtime path is:
+
+1. An inventory connector scans adjacent trims/cables and inventory providers every 20 server ticks.
+2. It resolves loader storage APIs into an aggregate handler (`MultiItemHandler` on Forge/NeoForge, corresponding wrappers on Fabric), applies priorities, and rejects obvious recursive networks.
+3. A storage terminal reads the adjacent aggregate, snapshots non-empty stacks as `StoredItemStack` totals, and performs insertion/extraction on the server.
+4. `StorageTerminalMenu.broadcastChanges()` sends incremental state through `TerminalSyncManager`.
+5. The client renders virtual storage slots rather than ordinary container slots.
+6. Client search, sort, and click actions return compact NBT payloads through `DataPacket`; the active server menu implements `IDataReceiver` and performs the actual mutation.
+
+All inventory mutations must remain server-authoritative. Preserve simulation/remainder semantics, item component/NBT equality, player inventory updates, and push-or-drop fallback behavior. Duplication and deletion bugs are the highest-risk regressions in this code.
+
+### Wireless And Remote Links
+
+- The wireless key path sends `OpenTerminalPacket`; the server locates a valid wireless terminal in player inventory and optional Curios/Trinkets slots before opening a menu.
+- Wireless range depends on server config, beacon level, dimension rules, and terminal binding state.
+- Inventory-link channels are stored in overworld `SavedData` under `toms_storage_rc`.
+- Channel owner, visibility, and display name persist; loaded connector positions are only an in-memory cache and repopulate as connectors register.
+- Remote lookup deliberately checks `isLoaded` and must not force-load chunks.
+
+### Configuration
+
+- Forge/NeoForge uses common and server config specs. Server values are world-specific under `saves/<world>/serverconfig`; common config includes multiblock inventory declarations.
+- Fabric uses Cloth AutoConfig/Gson and synchronizes the server configuration to clients during login.
+- Validation ranges and ownership differ by loader. A new option usually requires separate declaration, loading, synchronization, cache invalidation, and config-screen consideration.
+- There are no `.env` contracts.
+- `-DuseLib=true` enables optional REI/Cloth/Architectury dependencies in Forge/NeoForge builds. It is a presence/truthiness-tested JVM system property, not `-PuseLib=true`; even `-DuseLib=false` enables it, so omit the property to disable it.
+- `-DmavenDir=/absolute/path` selects a filesystem Maven publication destination.
+
+### External Integrations
+
+- JEI, REI, and EMI integrate recipe transfer and ghost ingredients with crafting terminals.
+- Curios on Forge/NeoForge and Trinkets on Fabric expose accessory slots for advanced wireless terminals.
+- Fabric additionally uses Fabric API, Cloth Config, Mod Menu, Cardinal Components, and Architectury.
+- Optional integration code must not load when its mod/API is absent. Keep metadata entry points and Gradle source exclusions synchronized with package/class changes.
+
+## Compatibility Contracts
+
+Treat the following as externally persistent or cross-side protocols. Do not rename or reinterpret them without an explicit migration plan:
+
+- block, item, block-entity, menu, and data-component registry IDs;
+- NBT keys written by block entities, items, menus, and `SavedData`;
+- `WorldPos` and item data-component codecs;
+- `toms_storage_rc` SavedData ID and inventory-link channel fields;
+- compact network keys such as `s`, `c`, and `d` shared by screens and menus;
+- packet IDs and `fabric.mod.json` entry-point class names;
+- recipe, tag, model, translation, and loot resource locations.
+
+Minecraft 1.20.6 moved important item state to data components. Do not backport component-based code mechanically to NBT-based older versions. Likewise, mapped signatures in access transformers/wideners are version-specific.
+
+## Change Workflow
+
+Before editing:
+
+1. Identify the exact target matrix cell: Minecraft version plus loader.
+2. Read that project's `build.gradle`, `gradle.properties`, and loader metadata.
+3. Trace its `sourceSets`; determine whether the authoritative file is local or inherited from a sibling project.
+4. Search the same class/resource name across all ports to understand loader and version differences.
+5. Decide whether the fix is loader-neutral, loader-family-specific, Minecraft-version-specific, or final-platform-specific.
+
+While editing:
+
+- Make the smallest correct change in the highest reusable source layer that actually feeds the target builds.
+- Do not bulk-copy a patch across all same-named files. Minecraft mappings, APIs, item persistence, payload registration, and capabilities differ by version and loader.
+- If behavior should be consistent across ports, list every affected target explicitly and adapt each implementation deliberately.
+- Preserve tabs and the existing compact Java style; opening braces stay on declaration lines.
+- Keep client-only classes out of dedicated-server class-loading paths.
+- Preserve the `toms_storage` namespace and existing dotted filename/registry conventions.
+- Update `en_us.json` first when adding translatable content, then update other locales only when accurate translations are available.
+- Never commit `.gradle/`, `build/`, `run/`, logs, local worlds, IDE metadata, or built JARs.
+
+For a new block or item, check all applicable surfaces:
+
+- `Content` and loader-specific registrations;
+- block entity, capability/storage exposure, menu, and screen registration;
+- block state, block/item model, texture, and painted-model handling;
+- loot table, recipe, advancement, and item/block tags;
+- English translation and creative-tab visibility;
+- server/client networking and config if behavior is interactive;
+- JEI/REI/EMI integration when crafting or ghost ingredients are involved.
+
+## Performance And Safety Hotspots
+
+- Connector scanning runs every 20 ticks and may traverse a large configurable area. Avoid forced chunk loads, repeated global scans, unbounded recursion, and avoidable allocations in this path.
+- Recursive storage networks are guarded by handler resolution and depth checks. Preserve cycle detection when changing wrappers or proxies.
+- Menu packets are weakly typed NBT. Validate active menu/state and never trust client-provided counts, slots, ownership, positions, or channel IDs.
+- Inventory transfers must correctly handle partial insertion/extraction and remainders. Test full inventories, mixed item components, double chests, filtered connectors, nested handlers, and disconnects.
+- Client/server separation is mandatory. Dedicated-server validation catches accidental references to screens, rendering, key bindings, or client-only integration classes.
+- Do not change remote links to load chunks. Unloaded endpoints should remain unavailable until naturally loaded.
+- Configurable scan limits and duplicate-network protections are intentional safeguards; do not bypass them for convenience.
+
+## Build And Run
+
+Run commands from the selected project directory, never from the repository root.
+
+NeoForge 1.20.6 example:
+
+```bash
+cd Toms-Storage-1206
+bash gradlew build
+bash gradlew runClient
+bash gradlew runServer
+bash gradlew runGameTestServer
+bash gradlew runData
+```
+
+Fabric 1.20.6 example, only after its sibling source paths are present or corrected as part of the task:
+
+```bash
+cd Toms-Storage-Fabric-1.20.6
+bash gradlew build
+bash gradlew runClient
+bash gradlew runServer
+```
+
+Useful project-local commands:
+
+```bash
+bash gradlew tasks
+bash gradlew test
+bash gradlew build -DuseLib=true
+bash gradlew publish -DmavenDir=/absolute/output/path
+```
+
+Builds resolve Minecraft, loader, and third-party artifacts from remote Maven repositories and therefore normally require network access. Standard outputs are project-local `.gradle/`, `build/`, and `run/`. Forge/NeoForge data generation writes to `src/generated/resources`; review generated changes before keeping them.
+
+## Validation Expectations
+
+There are currently no repository unit tests and no configured lint/formatter tool. GameTest run configurations exist, but no substantive GameTest suite is present. Forge 1.20.1's custom `test` dependency uses a mismatched generated client-task name in this checkout and is broken; `test` is not a reliable universal gate.
+
+Use the strongest practical validation for the changed target:
+
+1. Verify source-set paths exist and the edited file is included in the selected build.
+2. Run `bash gradlew build` in every explicitly affected project.
+3. For common gameplay or networking changes, smoke-test `runClient` and `runServer` where feasible.
+4. For client registration/rendering changes, launch a client and inspect missing-model/texture logs.
+5. For inventory changes, exercise insert, extract, shift-click, partial/full inventory, reconnect, filtered, and wireless paths.
+6. For persistence changes, load an existing world/item and verify round-trip save/reload behavior.
+7. For resource generation, inspect the diff; do not accept unrelated generated churn.
+
+If a build cannot run because expected sibling source directories are absent, report that precise blocker. Do not claim validation based only on a project that did not compile the modified shared source.
+
+## Release Metadata
+
+- Each project owns its `mod_version` in `gradle.properties`. Fabric artifact names are also properties; Forge/NeoForge artifact names are generally set in `build.gradle`.
+- Forge/NeoForge metadata lives under `src/main/resources/META-INF`; Fabric metadata lives in `src/main/resources/fabric.mod.json`.
+- Root `version-check.json` and `version-check-nf.json` are manually maintained update/release metadata.
+- There is no repository release automation, container deployment, or GitHub Actions pipeline.
+- `publish -DmavenDir=...` targets an explicit filesystem Maven repository; the standard `publishToMavenLocal` task can also write outside the workspace to the user's Maven cache.
+
+Version bumps and update JSON edits are release work. Do not include them in an ordinary bug fix unless requested. For metadata work, verify the declared Minecraft and loader ranges against the exact mapped target; several existing manifests use broad lower-bounded ranges, so do not copy or broaden compatibility ranges without deliberate testing.
+
+## Key Reference Files
+
+Use the 1.20.6 implementations as architecture references, then compare against the actual target port:
+
+- `Toms-Storage-1206/src/shared/java/com/tom/storagemod/Content.java`: canonical content and component declarations.
+- `Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/StorageMod.java`: NeoForge initialization.
+- `Toms-Storage-Fabric-1.20.6/src/loader-shared/java/com/tom/storagemod/StorageMod.java`: Fabric initialization and config sync.
+- `Toms-Storage-1206/src/main/java/com/tom/storagemod/platform/Platform.java`: NeoForge platform adapter.
+- `Toms-Storage-Fabric-1.20.6/src/main/java/com/tom/storagemod/platform/Platform.java`: Fabric platform adapter.
+- `Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/tile/InventoryConnectorBlockEntity.java`: network scan and aggregation.
+- `Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/tile/StorageTerminalBlockEntity.java`: terminal inventory operations and wireless checks.
+- `Toms-Storage-1206/src/shared/java/com/tom/storagemod/gui/StorageTerminalMenu.java`: virtual slots and server-authoritative interactions.
+- `Toms-Storage-1206/src/shared/java/com/tom/storagemod/util/TerminalSyncManager.java`: incremental terminal synchronization.
+- `Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/util/RemoteConnections.java`: inventory-link persistence and loaded-chunk behavior.
+- `Toms-Storage-1206/build.gradle`: NeoForge source composition and run tasks.
+- `Toms-Storage-Fabric-1.20.6/build.gradle`: Fabric dependencies and sibling source composition.

--- a/Toms-Storage-120/AGENTS.md
+++ b/Toms-Storage-120/AGENTS.md
@@ -1,0 +1,9 @@
+# Forge 1.20.1 Project
+
+Inherit repository rules from `../AGENTS.md`. This is the primary Minecraft 1.20.1 Forge 47.1.0 project and targets Java 17.
+
+- `main` overlays local `src/shared`, `src/loader-shared`, `src/platform-shared`, and default `src/main` Java/resources. The Java source layers exist locally, but configured `src/platform-shared/resources` is absent; there is no no-hyphen sibling-path blocker here.
+- Run commands here: `bash gradlew build`, `bash gradlew tasks`, and the project-specific client/server/data tasks shown by `tasks`. Networked dependency resolution is normally required.
+- Omitting JVM property `-DuseLib` excludes `com/tom/storagemod/rei/**`; any present value enables REI/Cloth/Architectury. JEI and EMI compile paths remain included. Keep Polymorph code aligned with its required dependency.
+- Strongest validation is `bash gradlew build`, then client and dedicated-server smoke tests for affected behavior. The custom `test` dependency names a mismatched client task and is not a reliable gate.
+- Preserve Forge 1.20.1 mappings, NBT formats, registry IDs, packet ordering, and resource locations; do not substitute NeoForge or newer data-component APIs.

--- a/Toms-Storage-120/src/loader-shared/java/AGENTS.md
+++ b/Toms-Storage-120/src/loader-shared/java/AGENTS.md
@@ -1,0 +1,7 @@
+# Forge-Shared Java Layer
+
+This layer owns Forge-family lifecycle, configuration, capabilities, block entities, storage wrappers, tags, models, and packets reusable by compatible Forge overlays.
+
+- Forge and Minecraft 1.20.1 APIs are allowed; NeoForge and Fabric APIs are not. Keep final registry/network adapters in `src/main/java` when they vary by target.
+- Shared Java may be consumed through sibling source sets, so compare legacy Forge counterparts before changing signatures or mapped APIs.
+- Preserve capability simulation, scan limits, loaded-chunk checks, NBT persistence, optional integration isolation, and dedicated-server safety.

--- a/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
+++ b/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
@@ -1,0 +1,7 @@
+# Forge Blocks
+
+Own Forge-specific proxy and framed cable block behavior layered over shared blocks.
+
+- Preserve capability exposure, framing/painting state, cable connectivity, drops, and recursion protection.
+- Inspect shared `block`, loader-shared `tile`/`util`, `Content`, platform registration, and synchronized models/block states/recipes.
+- Validate placement, wrench/removal paths, framed appearance, proxy recursion, capability access from every face, and dedicated-server loading.

--- a/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
+++ b/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
@@ -1,0 +1,7 @@
+# Forge Models
+
+Own Forge baked-model behavior for painted blocks.
+
+- Keep rendering client-only and preserve model-data, tint, particle, transform, and fallback behavior without server class-loading leaks.
+- Inspect `StorageModClient`, shared painted blocks/items, loader resource models/block states, and legacy Forge model counterparts.
+- Validate all painted variants, inventory and world rendering, resource reload, missing-model logs, and dedicated-server startup.

--- a/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
+++ b/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
@@ -1,0 +1,7 @@
+# Forge-Shared Network
+
+Own the wireless terminal open request consumed by the final Forge channel.
+
+- Treat the request as untrusted: verify the active player, item/binding, range, dimension, config, and optional Curios location server-side.
+- Inspect main `network`, shared wireless items, terminal block entities, config, and legacy Forge packet counterparts.
+- Validate inventory and Curios keys, missing/invalid bindings, out-of-range and cross-dimension denial, and absent Curios.

--- a/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/rei/AGENTS.md
+++ b/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/rei/AGENTS.md
@@ -1,0 +1,7 @@
+# Forge REI Bridge
+
+Own the Forge-side REI plugin bridge used only by the optional `-DuseLib` source composition.
+
+- Keep class/package names aligned with Gradle exclusions and shared `rei`; core or client initialization must not reference this bridge when REI is absent.
+- Inspect shared `rei`, `StorageModClient`, Gradle optional dependencies, and the legacy Forge 1.20.4 counterpart.
+- Validate default and `-DuseLib=true` builds, REI discovery, recipe transfer, and dedicated-server startup without REI.

--- a/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
+++ b/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
@@ -1,0 +1,7 @@
+# Forge Block Entities
+
+Own connector scans, aggregate storage access, terminals, crafting, hoppers, emitters, proxies, painting, and cable connector state.
+
+- Highest risk is item duplication/deletion: preserve capability simulation and remainders, cycle/depth guards, 20-tick scan behavior, loaded-chunk checks, NBT keys, and server authority.
+- Inspect shared `block`/`gui`/`item`, loader-shared `util`, main `platform`/`network`, `Content`, and equivalent legacy Forge block entities.
+- Validate partial/full insert/extract, double chests, filters/priorities, nested proxies, disconnects, wireless access, save/reload, and unloaded endpoints.

--- a/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
+++ b/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
@@ -1,0 +1,7 @@
+# Forge Storage Utilities
+
+Own Forge `IItemHandler` aggregation/filtering, registrations, remote links, inventory-link contracts, filters, and info helpers.
+
+- Preserve simulation/remainder behavior, handler ordering, cycle detection, `toms_storage_rc` persistence, owner/visibility fields, and the in-memory-only loaded-position cache.
+- Inspect loader-shared `tile`, shared `item`/`util`, main `platform`, config, and legacy Forge counterparts before changing interfaces.
+- Validate partial handlers, priorities, recursive networks, endpoint unload/reload, world save/reload, channel permissions, and no forced chunk loads.

--- a/Toms-Storage-120/src/loader-shared/resources/AGENTS.md
+++ b/Toms-Storage-120/src/loader-shared/resources/AGENTS.md
@@ -1,0 +1,7 @@
+# Forge-Shared Resources
+
+Own Forge-family resource overlays: framed/painted states, Forge-era recipes/tags, and Curios slot/entity data.
+
+- Keep resource IDs synchronized with loader-shared Java registrations and shared assets; preserve `toms_storage`, `minecraft`, and `curios` namespace contracts.
+- Coordinate recipe changes with item/block IDs and tags, Curios data with wireless lookup, and painted states with model registration.
+- Validate with resource-pack logs, recipe loading, Curios equipped access, tags/mining behavior, painted models, and dedicated-server data loading.

--- a/Toms-Storage-120/src/main/java/AGENTS.md
+++ b/Toms-Storage-120/src/main/java/AGENTS.md
@@ -1,0 +1,7 @@
+# Final Forge Java Layer
+
+This layer owns final Minecraft 1.20.1 Forge adapters not suitable for shared overlays: channel registration, registry/platform access, screens, and Polymorph integration.
+
+- Forge 1.20.1 and integration APIs are allowed; NeoForge and Fabric APIs are not. Do not move broadly reusable gameplay into this layer.
+- Inspect shared, loader-shared, and platform-shared contracts before changing implementations.
+- Preserve packet discriminators, registry IDs, capability semantics, optional integration loading, and client/server class separation.

--- a/Toms-Storage-120/src/main/java/com/tom/storagemod/network/AGENTS.md
+++ b/Toms-Storage-120/src/main/java/com/tom/storagemod/network/AGENTS.md
@@ -1,0 +1,7 @@
+# Forge Network Adapter
+
+Own the Forge `SimpleChannel`, packet discriminators, `DataPacket` serialization, and server dispatch.
+
+- Preserve channel ID/version, discriminator order, compact NBT keys, active-menu checks, enqueue direction, and server-authoritative validation.
+- Inspect shared `gui`/`util`, loader-shared `OpenTerminalPacket`, main `platform`, and legacy Forge network adapters.
+- Validate malformed and stale menu packets, insert/extract/crafting actions, wireless opening, client/server compatibility, and dedicated-server startup.

--- a/Toms-Storage-120/src/main/java/com/tom/storagemod/platform/AGENTS.md
+++ b/Toms-Storage-120/src/main/java/com/tom/storagemod/platform/AGENTS.md
@@ -1,0 +1,7 @@
+# Forge Platform Adapter
+
+Own Forge registries, creative tab, interaction helpers, capability access, menu/screen construction, and final platform implementations.
+
+- Preserve registry names, registration timing, sided class loading, capability invalidation, interaction results, and menu payload formats.
+- Inspect `Content`, loader-shared lifecycle/block entities/utilities, platform-shared helpers, resources, and legacy Forge platform adapters.
+- Validate registration, creative-tab entries, block/menu opening, capability exposure/invalidation, client rendering, and dedicated-server launch.

--- a/Toms-Storage-120/src/main/java/com/tom/storagemod/polymorph/AGENTS.md
+++ b/Toms-Storage-120/src/main/java/com/tom/storagemod/polymorph/AGENTS.md
@@ -1,0 +1,7 @@
+# Polymorph Integration
+
+Own Polymorph crafting-terminal recipe selection data and client widget integration for Forge 1.20.1.
+
+- Keep recipe choice synchronized with the crafting terminal and avoid loading client widget classes on dedicated servers.
+- Inspect crafting terminal menus/screens/block entities, recipe placement helpers, platform recipe code, and the Polymorph dependency declaration.
+- Validate multiple matching recipes, selection persistence, matrix changes, item remainders, absence/error isolation, and dedicated-server startup.

--- a/Toms-Storage-120/src/main/resources/AGENTS.md
+++ b/Toms-Storage-120/src/main/resources/AGENTS.md
@@ -1,0 +1,7 @@
+# Forge 1.20.1 Metadata Resources
+
+Own `pack.mcmeta` and Forge metadata/access-transformer inputs for the final 1.20.1 artifact.
+
+- Keep `mods.toml`, Forge/Minecraft ranges, access-transformer mapped signatures, mod ID, and update metadata aligned with this exact Forge 1.20.1 target.
+- Synchronize access changes with Java call sites and verify optional integrations remain optional; do not create guidance files inside `META-INF`.
+- Validate `bash gradlew build`, inspect the packaged JAR inputs, and launch client and dedicated server for metadata or transformer changes.

--- a/Toms-Storage-120/src/platform-shared/java/AGENTS.md
+++ b/Toms-Storage-120/src/platform-shared/java/AGENTS.md
@@ -1,0 +1,7 @@
+# Minecraft 1.20.1 Platform Layer
+
+This layer owns mapped Minecraft 1.20.1 recipe, screen-widget, menu, and `SavedData` signature differences shared across loaders where possible.
+
+- Minecraft and project abstractions are allowed; Forge, NeoForge, Fabric, capabilities, and loader lifecycle imports are not.
+- Inspect corresponding 1.20.2/1.20.4 platform layers and final adapters before changing mapped signatures; do not copy newer data-component APIs here.
+- Preserve recipe placement, menu synchronization, client-only boundaries, and `SavedData` compatibility.

--- a/Toms-Storage-120/src/platform-shared/java/com/tom/storagemod/jei/AGENTS.md
+++ b/Toms-Storage-120/src/platform-shared/java/com/tom/storagemod/jei/AGENTS.md
@@ -1,0 +1,7 @@
+# JEI Platform Adapter
+
+Own the Minecraft 1.20.1-specific JEI recipe transfer bridge.
+
+- Preserve crafting slot indices, ingredient quantities, remainder handling, and the boundary between JEI callbacks and server-authoritative menu actions.
+- Inspect shared `jei`, shared `gui`/`util`, main networking, and later-version platform transfer handlers.
+- Validate shaped/shapeless transfers, missing and partial ingredients, full inventory, ghost-only behavior, and absence of JEI at runtime.

--- a/Toms-Storage-120/src/platform-shared/java/com/tom/storagemod/platform/AGENTS.md
+++ b/Toms-Storage-120/src/platform-shared/java/com/tom/storagemod/platform/AGENTS.md
@@ -1,0 +1,7 @@
+# Version Platform Helpers
+
+Own Minecraft 1.20.1 mapped helpers for recipes, recipe-book widgets, edit boxes, menus, and `SavedData` factories.
+
+- Preserve mapped signatures, client/server separation, crafting grid semantics, and existing persistence factories.
+- Inspect shared `gui`/`util`, main `platform`, platform counterparts in later versions, and vanilla call sites.
+- Validate recipe placement/remainders, recipe-book interaction, text editing, menu opening, and world save/load.

--- a/Toms-Storage-120/src/shared/java/AGENTS.md
+++ b/Toms-Storage-120/src/shared/java/AGENTS.md
@@ -1,0 +1,7 @@
+# Shared Java Layer
+
+This local layer owns gameplay, blocks, items, menus/screens, terminal synchronization, and optional recipe-viewer adapters reused by this project's overlays.
+
+- Keep code loader-neutral: Minecraft APIs and project abstractions are allowed; Forge, NeoForge, Fabric, and loader lifecycle imports are not.
+- Route registration, networking, capabilities, and platform signatures through existing abstractions and inspect `src/loader-shared/java`, `src/platform-shared/java`, and `src/main/java` before changing a boundary.
+- Preserve server authority, NBT/protocol keys, registry IDs, client/server separation, and inventory remainder semantics.

--- a/Toms-Storage-120/src/shared/java/com/tom/storagemod/block/AGENTS.md
+++ b/Toms-Storage-120/src/shared/java/com/tom/storagemod/block/AGENTS.md
@@ -1,0 +1,7 @@
+# Shared Blocks
+
+Own loader-neutral block behavior for terminals, cables, connectors, trims, hoppers, emitters, and crates.
+
+- Preserve registry IDs, block-state properties, paint behavior, menu opening, and cable/trim connectivity; avoid chunk loads or bypassing network-cycle safeguards.
+- Inspect `Content`, matching block entities in `src/loader-shared/java/com/tom/storagemod/tile`, platform registration, block states, models, loot, recipes, and tags.
+- Validate placement/removal, rotations and states, terminal opening, cable reconnection, painted variants, drops, and a dedicated-server launch.

--- a/Toms-Storage-120/src/shared/java/com/tom/storagemod/emi/AGENTS.md
+++ b/Toms-Storage-120/src/shared/java/com/tom/storagemod/emi/AGENTS.md
@@ -1,0 +1,7 @@
+# EMI Integration
+
+Own EMI plugin, ghost ingredients, and crafting-terminal transfer for the Forge 1.20.1 line.
+
+- Keep EMI optional and preserve ingredient accounting, menu mapping, and server-authoritative terminal actions; no EMI classes may leak into core startup.
+- Inspect shared `gui`/`util`, main networking, `Content`, and the project's EMI compile/runtime dependencies.
+- Validate with and without EMI, ghost placement, partial/full inventories, recipe transfer remainders, and dedicated-server loading.

--- a/Toms-Storage-120/src/shared/java/com/tom/storagemod/gui/AGENTS.md
+++ b/Toms-Storage-120/src/shared/java/com/tom/storagemod/gui/AGENTS.md
@@ -1,0 +1,7 @@
+# Shared GUI
+
+Own terminal/filter/link menus and screens, virtual storage slots, search/sort controls, and crafting transfer surfaces.
+
+- Keep mutations server-authoritative and preserve compact packet keys, slot/count validation, shift-click remainders, ghost slots, and client-only class isolation.
+- Inspect loader-shared block entities, shared `util` synchronization/crafting helpers, main `network` and `platform`, and JEI/REI/EMI handlers.
+- Validate insert/extract, shift-click, full inventory, search/sort, reconnect, recipe fill, malformed actions, and dedicated-server startup.

--- a/Toms-Storage-120/src/shared/java/com/tom/storagemod/item/AGENTS.md
+++ b/Toms-Storage-120/src/shared/java/com/tom/storagemod/item/AGENTS.md
@@ -1,0 +1,7 @@
+# Shared Items
+
+Own filters, paint kits, painted block items, and NBT-based wireless terminal items for Minecraft 1.20.1.
+
+- Preserve item NBT keys, bindings, filter matching, stack equality, registry IDs, and server-side wireless authorization; do not backport data components.
+- Inspect `Content`, filter handlers in loader-shared `util`, terminal block entities, GUI packages, Curios lookup, recipes, models, and translations.
+- Validate NBT save/reload, bind/unbind, range and dimension rules, filter variants, painted placement, and full-inventory behavior.

--- a/Toms-Storage-120/src/shared/java/com/tom/storagemod/jei/AGENTS.md
+++ b/Toms-Storage-120/src/shared/java/com/tom/storagemod/jei/AGENTS.md
@@ -1,0 +1,7 @@
+# JEI Integration
+
+Own JEI discovery, ghost ingredients, and crafting-terminal recipe transfer for Forge 1.20.1.
+
+- Keep JEI optional at runtime and preserve menu slot mapping, ingredient counts, and server-authoritative transfer through normal terminal packets.
+- Inspect shared `gui`/`util`, platform-shared `PlatformRecipeTransferHandler`, main networking, and JEI Gradle dependencies.
+- Validate with and without JEI, ghost placement, partial ingredients, full player inventory, and dedicated-server class loading.

--- a/Toms-Storage-120/src/shared/java/com/tom/storagemod/rei/AGENTS.md
+++ b/Toms-Storage-120/src/shared/java/com/tom/storagemod/rei/AGENTS.md
@@ -1,0 +1,7 @@
+# REI Integration
+
+Own REI plugin, ghost ingredients, and crafting-terminal transfer code compiled only when `-DuseLib` is present.
+
+- Keep package paths aligned with the Gradle exclusion and loader-shared `REIPlugin_`; never make core initialization load REI classes when absent.
+- Inspect shared `gui`/`util`, loader-shared `rei`, main networking, and optional REI/Cloth/Architectury dependencies.
+- Validate `bash gradlew build -DuseLib=true`, the default exclusion build, recipe transfer edge cases, and dedicated-server startup without REI.

--- a/Toms-Storage-120/src/shared/java/com/tom/storagemod/util/AGENTS.md
+++ b/Toms-Storage-120/src/shared/java/com/tom/storagemod/util/AGENTS.md
@@ -1,0 +1,7 @@
+# Shared Utilities
+
+Own terminal snapshots and sync, crafting matrix/fill logic, player inventory helpers, priorities, packet receiver contracts, and formatting helpers.
+
+- Preserve item-plus-NBT equality, incremental sync ordering, compact protocol keys, simulation/remainder semantics, and push-or-drop behavior.
+- Inspect shared `gui`, loader-shared `util` and `tile`, main `network`, and recipe-viewer transfer handlers before changing contracts.
+- Validate partial/full transfers, duplicate stacks with distinct NBT, reconnect synchronization, crafting remainder items, and invalid client payloads.

--- a/Toms-Storage-120/src/shared/resources/AGENTS.md
+++ b/Toms-Storage-120/src/shared/resources/AGENTS.md
@@ -1,0 +1,7 @@
+# Shared Resources
+
+Own loader-neutral `toms_storage` assets and data: block states, models, textures, translations, loot, recipes, advancements, and tags.
+
+- Preserve dotted resource locations and registry-linked paths. Synchronize content changes with `Content`, blocks/items, loot, recipes, tags, models, textures, and `en_us.json` first.
+- Do not place Forge-only Curios data or loader metadata here. Check loader-shared overlays for deliberate overrides.
+- Validate resource loading in client logs, block/item rendering, recipes, drops, tags, translations, and generated-resource diffs.

--- a/Toms-Storage-1202/AGENTS.md
+++ b/Toms-Storage-1202/AGENTS.md
@@ -1,0 +1,21 @@
+# NeoForge 1.20.2 Project
+
+Inherit repository-wide rules from `../AGENTS.md`; this file covers only Minecraft 1.20.2 on NeoForge 20.2 with Java 17.
+
+## Source Composition
+
+- `main` combines local `src/main/java`, `src/loader-shared/java`, and `src/platform-shared/java` with shared Java from `../TomsStorage-120/src/shared/java`.
+- Shared resources likewise come from `../TomsStorage-120/src/shared/resources`; the local loader resource root overlays them, while configured `src/platform-shared/resources` is absent.
+- This checkout has `Toms-Storage-120`, not the referenced no-hyphen `TomsStorage-120`. The inherited shared source is therefore absent from this build. Treat compilation as blocked or incomplete until that exact source-set path exists; do not silently repair it outside the task scope.
+- This is an NBT-era port. Item bindings, filters, menu messages, and persistence use the 1.20.2 conventions; do not introduce 1.20.6 data components or payload codecs.
+
+## Integrations
+
+- With `useLib` absent, `com/tom/storagemod/rei/**` is excluded. `jei/**` and `emi/**` are always excluded from Java compilation here.
+- `-DuseLib=true` enables REI, Cloth Config, and Architectury. Curios API is compile-only and Curios is present at runtime.
+
+## Commands And Validation
+
+- Run locally: `bash gradlew build`, `bash gradlew runClient`, `bash gradlew runServer`, `bash gradlew runGameTestServer`, and `bash gradlew runData`.
+- First verify every `sourceSets` path exists. Once the shared-source blocker is resolved, the strongest general gate is `bash gradlew build`, followed by client and dedicated-server smoke tests for gameplay, networking, or registration changes.
+- Validate optional code both without `useLib` and with `bash gradlew build -DuseLib=true` when REI-related paths change.

--- a/Toms-Storage-1202/src/loader-shared/java/AGENTS.md
+++ b/Toms-Storage-1202/src/loader-shared/java/AGENTS.md
@@ -1,0 +1,8 @@
+# NeoForge Loader-Shared Java Layer
+
+This layer owns NeoForge-family lifecycle, configuration, capabilities, networking hooks, block entities, storage wrappers, tags, and client model wiring for 1.20.2.
+
+- NeoForge APIs are allowed; Fabric APIs are not. Keep generally reusable gameplay in the inherited shared layer.
+- Client-only imports belong behind client initialization or in explicitly client-only classes.
+- Preserve NBT-era persistence and packet behavior; do not use 1.20.6 data-component or payload-codec APIs.
+- Validate with build, client startup, dedicated-server startup, and focused inventory/network smoke tests after the inherited-source blocker is resolved.

--- a/Toms-Storage-1202/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
+++ b/Toms-Storage-1202/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
@@ -1,0 +1,6 @@
+# NeoForge Block Extensions
+
+- Owns framed cable and inventory-proxy blocks that depend on NeoForge behavior.
+- Preserve connection shapes, proxy recursion guards, paint state, and block-entity pairing.
+- Inspect inherited shared `block`, local `tile`, `Content`, blockstates, models, recipes, and loot counterparts before changes.
+- Validate placement/breaking, cable connectivity, proxy capability access, painting, and missing-model logs.

--- a/Toms-Storage-1202/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
+++ b/Toms-Storage-1202/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
@@ -1,0 +1,6 @@
+# Client Models
+
+- Owns NeoForge baked-model handling for painted blocks.
+- Keep model registration client-only and preserve source model transforms, render types, and paint texture resolution.
+- Inspect `StorageModClient`, painted block/item classes, and loader/shared blockstate and model resources together.
+- Validate client startup, resource reload, inventory rendering, placed rendering, and missing-model/texture logs.

--- a/Toms-Storage-1202/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
+++ b/Toms-Storage-1202/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
@@ -1,0 +1,6 @@
+# Loader Network Features
+
+- Owns the wireless terminal open request; final channel transport remains in `src/main/java/.../network`.
+- Never trust client position, item, range, or ownership claims. Resolve the valid terminal server-side and preserve Curios lookup behavior.
+- Inspect wireless items, terminal block entities, config range rules, and final `NetworkHandler` before protocol changes.
+- Validate normal and advanced wireless opening, out-of-range/cross-dimension rejection, Curios presence/absence, and malformed requests.

--- a/Toms-Storage-1202/src/loader-shared/java/com/tom/storagemod/rei/AGENTS.md
+++ b/Toms-Storage-1202/src/loader-shared/java/com/tom/storagemod/rei/AGENTS.md
@@ -1,0 +1,6 @@
+# Optional REI Bootstrap
+
+- Bridges NeoForge discovery to the inherited REI integration and is compiled only when the JVM system property `useLib` is present.
+- Do not make core or client initialization load REI classes when the integration is excluded or REI is absent.
+- Inspect the inherited shared `rei` package, Gradle exclusions, and optional dependency declarations together.
+- Validate a normal build without `useLib` and `bash gradlew build -DuseLib=true` once the source-set blocker is resolved.

--- a/Toms-Storage-1202/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
+++ b/Toms-Storage-1202/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
@@ -1,0 +1,6 @@
+# NeoForge Block Entities
+
+- Owns storage network scanning, capability aggregation, terminals, connectors, hoppers, emitters, proxies, and painted block entities.
+- Inventory mutation is server-authoritative. Preserve simulation/remainders, 20-tick scan limits, cycle detection, NBT keys, loaded-chunk checks, and push-or-drop behavior.
+- Inspect inherited shared blocks/menus/items, local util handlers, `Content`, `Platform`, and equivalent 1.20.4 block entities before changes.
+- Validate insert/extract and partial/full inventories, reconnects, filters, recursive networks, wireless range, save/reload, and unloaded remote endpoints.

--- a/Toms-Storage-1202/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
+++ b/Toms-Storage-1202/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
@@ -1,0 +1,6 @@
+# NeoForge Storage Utilities
+
+- Owns capability wrappers, filters, aggregate handlers, registry wrappers, remote-link `SavedData`, proxy interfaces, and info hooks.
+- Preserve item NBT equality, simulation/remainder contracts, priority order, recursion limits, `toms_storage_rc` fields, and no-force-load remote lookup.
+- Inspect block entities, inherited shared item/filter utilities, `Platform`, config, and 1.20.4 equivalents before changes.
+- Validate mixed NBT stacks, partial transfers, nested handlers, filter modes, priority, world reload, and unloaded channels.

--- a/Toms-Storage-1202/src/loader-shared/resources/AGENTS.md
+++ b/Toms-Storage-1202/src/loader-shared/resources/AGENTS.md
@@ -1,0 +1,6 @@
+# NeoForge Loader-Shared Resources
+
+- Owns NeoForge/Curios-sensitive recipes, tags, Curios slot data, and the painted-trim blockstate overlay for 1.20.2.
+- Preserve `toms_storage` IDs and dotted filenames; synchronize changed content with `Content`, blocks/items, models, loot, translations, and inherited shared resources.
+- Keep Curios resources consistent with optional accessory lookup and avoid duplicating loader-neutral assets here.
+- Validate data/resource loading, recipes and tags, Curios belt use, painted trim rendering, and missing-resource logs.

--- a/Toms-Storage-1202/src/main/java/AGENTS.md
+++ b/Toms-Storage-1202/src/main/java/AGENTS.md
@@ -1,0 +1,8 @@
+# Final NeoForge Java Layer
+
+This layer contains the 1.20.2 NeoForge-specific network and platform adapters that complete the composed source set.
+
+- NeoForge and mapped 1.20.2 imports are allowed here; Fabric imports are not.
+- Keep client-only screen adapters out of dedicated-server loading paths.
+- Preserve the NBT-based packet contract and delegate reusable behavior to inherited shared or local loader-shared code.
+- Validate with compilation plus client/server packet and interaction smoke tests after resolving the project source-set blocker.

--- a/Toms-Storage-1202/src/main/java/com/tom/storagemod/network/AGENTS.md
+++ b/Toms-Storage-1202/src/main/java/com/tom/storagemod/network/AGENTS.md
@@ -1,0 +1,6 @@
+# Final Network Adapters
+
+- Owns 1.20.2 `DataPacket` transport and channel registration.
+- Keep active-menu checks, `IDataReceiver` dispatch, compact NBT keys, and server authority intact; malformed client data must not mutate arbitrary state.
+- Inspect loader-shared `network/OpenTerminalPacket`, inherited shared menus/screens, and 1.20.4's equivalent network package before changing protocol behavior.
+- Validate packet encode/decode, wrong-menu rejection, terminal actions, wireless opening, and dedicated-server startup.

--- a/Toms-Storage-1202/src/main/java/com/tom/storagemod/platform/AGENTS.md
+++ b/Toms-Storage-1202/src/main/java/com/tom/storagemod/platform/AGENTS.md
@@ -1,0 +1,6 @@
+# Final Platform Adapters
+
+- Implements NeoForge registration, interaction, storage capability, and container-screen hooks requested by shared code.
+- Preserve simulation/remainder semantics, registry IDs, sided behavior, and client/server class separation.
+- Inspect local loader-shared block entities/util handlers and the 1.20.4 NeoForge adapter before adapting mapped signatures.
+- Validate compilation, content registration, inventory insertion/extraction, menu opening, and dedicated-server startup.

--- a/Toms-Storage-1202/src/main/resources/AGENTS.md
+++ b/Toms-Storage-1202/src/main/resources/AGENTS.md
@@ -1,0 +1,6 @@
+# Final NeoForge Resources
+
+- Owns 1.20.2 `pack.mcmeta`, NeoForge metadata under `META-INF`, and the version-specific access transformer.
+- Keep metadata ranges aligned with `gradle.properties` and mapped access-transformer signatures; do not add guidance files inside `META-INF`.
+- Coordinate metadata class names and dependencies with loader initialization and Gradle dependency/exclusion behavior.
+- Validate `processResources`/build output, dedicated-server discovery, and any transformed access at runtime after resolving source composition.

--- a/Toms-Storage-1202/src/platform-shared/java/AGENTS.md
+++ b/Toms-Storage-1202/src/platform-shared/java/AGENTS.md
@@ -1,0 +1,8 @@
+# Minecraft 1.20.2 Platform-Shared Java Layer
+
+This layer isolates mapped 1.20.2 recipe, screen-widget, JEI transfer, and `SavedData` API differences.
+
+- Minecraft API imports and loader-neutral project abstractions are allowed; NeoForge- or Fabric-specific imports are not.
+- Keep behavior portable across loaders for this Minecraft version and avoid moving NBT-era code toward 1.20.6 components/codecs.
+- Compare both loader adapters and adjacent Minecraft-version implementations before changing mapped signatures.
+- Validate every composed loader target that consumes a changed abstraction; for this project, first account for its missing inherited source path.

--- a/Toms-Storage-1202/src/platform-shared/java/com/tom/storagemod/jei/AGENTS.md
+++ b/Toms-Storage-1202/src/platform-shared/java/com/tom/storagemod/jei/AGENTS.md
@@ -1,0 +1,6 @@
+# JEI Version Adapter
+
+- Adapts crafting-terminal recipe transfer to the 1.20.2 JEI/Minecraft API boundary.
+- Preserve server-authoritative crafting, slot mapping, ingredient counts, and menu validity; this project excludes `jei/**` from compilation.
+- Inspect inherited shared JEI handlers, crafting menus, platform recipe abstractions, and a target that actually compiles this adapter before edits.
+- Validation here requires a consuming build with JEI enabled; this project's ordinary build is not evidence because the package is excluded.

--- a/Toms-Storage-1202/src/platform-shared/java/com/tom/storagemod/platform/AGENTS.md
+++ b/Toms-Storage-1202/src/platform-shared/java/com/tom/storagemod/platform/AGENTS.md
@@ -1,0 +1,6 @@
+# Minecraft 1.20.2 Abstractions
+
+- Owns mapped recipe, recipe-book button, edit-box, menu, and `SavedData` factory differences shared across loaders.
+- Keep loader APIs out and preserve behavior expected by shared menus, screens, recipes, and remote-link persistence.
+- Inspect final `Platform`, inherited shared GUI/recipe callers, local remote connections, and adjacent version implementations.
+- Validate recipe lookup/transfer, widget behavior, menu interaction, and save/reload through each consuming loader build.

--- a/Toms-Storage-1204/AGENTS.md
+++ b/Toms-Storage-1204/AGENTS.md
@@ -1,0 +1,20 @@
+# NeoForge 1.20.4 Project
+
+Inherit repository-wide rules from `../AGENTS.md`; this file covers only Minecraft 1.20.4 on NeoForge 20.4 with Java 17.
+
+## Source Composition
+
+- `main` combines local default `src/main/java` and resources with `src/shared`, `src/loader-shared`, and `src/platform-shared`; all referenced source roots exist locally except the configured but absent `src/platform-shared/resources`.
+- Shared is loader-neutral, loader-shared owns NeoForge-family code, platform-shared isolates 1.20.4 mappings, and main supplies final NeoForge adapters.
+- This is an NBT-era port. Keep item bindings, filters, menu messages, and persistence on 1.20.4 NBT conventions; do not backport 1.20.6 data components or payload codecs.
+
+## Integrations
+
+- With `useLib` absent, only `com/tom/storagemod/rei/**` is excluded. JEI and EMI source remains compiled; JEI has runtime support while EMI is API-only by default.
+- `-DuseLib=true` enables REI, Cloth Config, and Architectury. Curios is API-only in the default dependency set.
+
+## Commands And Validation
+
+- Run locally: `bash gradlew build`, `bash gradlew runClient`, `bash gradlew runServer`, `bash gradlew runGameTestServer`, and `bash gradlew runData`.
+- The strongest general gate is `bash gradlew build`, followed by client and dedicated-server smoke tests for gameplay, networking, registration, or client changes.
+- Validate optional code both with a normal build and `bash gradlew build -DuseLib=true` when REI-related paths change; inspect generated resource diffs after `runData`.

--- a/Toms-Storage-1204/src/loader-shared/java/AGENTS.md
+++ b/Toms-Storage-1204/src/loader-shared/java/AGENTS.md
@@ -1,0 +1,8 @@
+# NeoForge Loader-Shared Java Layer
+
+This layer owns NeoForge-family lifecycle, configuration, networking, capabilities, block entities, storage wrappers, tags, and client model wiring for 1.20.4.
+
+- NeoForge APIs are allowed; Fabric APIs are not. Keep reusable gameplay in `src/shared/java`.
+- Client imports belong behind client initialization or in explicitly client-only classes.
+- Preserve NBT-era persistence and packet behavior; do not use 1.20.6 data-component or payload-codec APIs.
+- Validate build, client startup, dedicated-server startup, and focused inventory/network behavior.

--- a/Toms-Storage-1204/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
+++ b/Toms-Storage-1204/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
@@ -1,0 +1,6 @@
+# NeoForge Block Extensions
+
+- Owns framed cable and inventory-proxy blocks that depend on NeoForge behavior.
+- Preserve connection shapes, proxy recursion guards, paint state, and block-entity pairing.
+- Inspect shared `block`, local `tile`, `Content`, blockstates, models, recipes, loot, and 1.20.6 counterparts.
+- Validate placement/breaking, cable connectivity, proxy capability access, painting, and missing-model logs.

--- a/Toms-Storage-1204/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
+++ b/Toms-Storage-1204/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
@@ -1,0 +1,6 @@
+# Client Models
+
+- Owns NeoForge baked-model handling for painted blocks.
+- Keep registration client-only and preserve source model transforms, render types, and paint texture resolution.
+- Inspect `StorageModClient`, painted block/item classes, and loader/shared blockstate and model resources together.
+- Validate client startup, resource reload, inventory rendering, placed rendering, and missing-model/texture logs.

--- a/Toms-Storage-1204/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
+++ b/Toms-Storage-1204/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
@@ -1,0 +1,6 @@
+# NBT Network Transport
+
+- Owns 1.20.4 channel registration, generic `DataPacket` dispatch, and wireless terminal open requests.
+- Preserve compact NBT keys, encode/decode symmetry, active-menu checks, server authority, and server-side wireless item/range/ownership resolution.
+- Inspect shared GUI and `IDataReceiver`, wireless items, terminal block entities, config, and 1.20.2/1.20.6 network counterparts.
+- Validate malformed packets, wrong-menu rejection, terminal actions, wireless/Curios paths, and dedicated-server startup.

--- a/Toms-Storage-1204/src/loader-shared/java/com/tom/storagemod/rei/AGENTS.md
+++ b/Toms-Storage-1204/src/loader-shared/java/com/tom/storagemod/rei/AGENTS.md
@@ -1,0 +1,6 @@
+# Optional REI Bootstrap
+
+- Bridges NeoForge discovery to shared REI integration and is compiled only when `useLib` is present.
+- Do not make core or client initialization load REI classes when the package is excluded or REI is absent.
+- Inspect shared `rei`, Gradle exclusions/dependencies, metadata discovery, and adjacent version implementations together.
+- Validate a normal build without `useLib` and `bash gradlew build -DuseLib=true`.

--- a/Toms-Storage-1204/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
+++ b/Toms-Storage-1204/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
@@ -1,0 +1,6 @@
+# NeoForge Block Entities
+
+- Owns network scanning, capability aggregation, terminals, connectors, hoppers, emitters, proxies, and painted block entities.
+- Inventory mutation is server-authoritative. Preserve simulation/remainders, 20-tick scan limits, cycle detection, NBT keys, loaded-chunk checks, and push-or-drop behavior.
+- Inspect shared blocks/menus/items, loader util handlers, `Content`, `Platform`, resources, and 1.20.6 block entities.
+- Validate partial/full insert/extract, reconnects, filters, recursive networks, wireless range, save/reload, and unloaded remote endpoints.

--- a/Toms-Storage-1204/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
+++ b/Toms-Storage-1204/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
@@ -1,0 +1,6 @@
+# NeoForge Storage Utilities
+
+- Owns capability wrappers, filters, aggregate handlers, registry wrappers, remote-link `SavedData`, proxy interfaces, and info hooks.
+- Preserve item NBT equality, simulation/remainders, priority order, recursion limits, `toms_storage_rc` fields, and no-force-load lookup.
+- Inspect block entities, shared item/util/filter callers, `Platform`, config, and 1.20.6 component-aware equivalents.
+- Validate mixed-NBT stacks, partial transfers, nested handlers, filter modes, priority, world reload, and unloaded channels.

--- a/Toms-Storage-1204/src/loader-shared/resources/AGENTS.md
+++ b/Toms-Storage-1204/src/loader-shared/resources/AGENTS.md
@@ -1,0 +1,6 @@
+# NeoForge Loader-Shared Resources
+
+- Owns NeoForge/Curios-sensitive recipes, tags, Curios slot data, and the painted-trim blockstate overlay.
+- Preserve `toms_storage` IDs and dotted filenames; synchronize with loader blocks/items, `Content`, shared models/loot/translations, and Curios lookup code.
+- Avoid duplicating loader-neutral assets that belong in `src/shared/resources`.
+- Validate data/resource loading, recipes and tags, Curios belt behavior, painted trim rendering, and missing-resource logs.

--- a/Toms-Storage-1204/src/main/java/AGENTS.md
+++ b/Toms-Storage-1204/src/main/java/AGENTS.md
@@ -1,0 +1,8 @@
+# Final NeoForge Java Layer
+
+This layer contains the final 1.20.4 NeoForge platform adapters for registration, interactions, storage capabilities, and container screens.
+
+- NeoForge and mapped 1.20.4 imports are allowed; Fabric imports are not.
+- Keep client-only screen code out of dedicated-server loading paths and reusable logic in higher shared layers.
+- Preserve capability simulation/remainder behavior, registry IDs, and NBT-era contracts.
+- Validate compilation, client and dedicated-server startup, registration, menu opening, and inventory transfer behavior.

--- a/Toms-Storage-1204/src/main/java/com/tom/storagemod/platform/AGENTS.md
+++ b/Toms-Storage-1204/src/main/java/com/tom/storagemod/platform/AGENTS.md
@@ -1,0 +1,6 @@
+# Final Platform Adapters
+
+- Implements NeoForge registration, interaction, capability, item, recipe, and container-screen requests from shared code.
+- Preserve simulation/remainder semantics, registry IDs, sided capability exposure, and client/server class separation.
+- Inspect loader-shared block entities/util handlers, platform-shared abstractions, `Content`, and the 1.20.6 adapter before mapped changes.
+- Validate content registration, insert/extract, menu opening, recipe behavior, client startup, and dedicated-server startup.

--- a/Toms-Storage-1204/src/main/resources/AGENTS.md
+++ b/Toms-Storage-1204/src/main/resources/AGENTS.md
@@ -1,0 +1,6 @@
+# Final NeoForge Resources
+
+- Owns 1.20.4 `pack.mcmeta`, NeoForge metadata under `META-INF`, and the version-specific access transformer.
+- Keep metadata ranges aligned with `gradle.properties` and mapped access-transformer signatures; do not add guidance files inside `META-INF`.
+- Coordinate metadata class names and optional dependencies with loader initialization and Gradle integration behavior.
+- Validate `processResources`/build output, client and dedicated-server discovery, and transformed access at runtime.

--- a/Toms-Storage-1204/src/platform-shared/java/AGENTS.md
+++ b/Toms-Storage-1204/src/platform-shared/java/AGENTS.md
@@ -1,0 +1,8 @@
+# Minecraft 1.20.4 Platform-Shared Java Layer
+
+This layer isolates mapped 1.20.4 recipe, screen-widget, JEI transfer, and `SavedData` API differences shared across loaders.
+
+- Minecraft API imports and loader-neutral project abstractions are allowed; NeoForge and Fabric APIs are not.
+- Keep behavior portable across loaders for this Minecraft version and retain NBT-era contracts.
+- Compare both loader adapters and adjacent Minecraft-version implementations before changing mapped signatures.
+- Validate every consuming loader build plus focused recipe, screen, and persistence behavior.

--- a/Toms-Storage-1204/src/platform-shared/java/com/tom/storagemod/jei/AGENTS.md
+++ b/Toms-Storage-1204/src/platform-shared/java/com/tom/storagemod/jei/AGENTS.md
@@ -1,0 +1,6 @@
+# JEI Version Adapter
+
+- Adapts crafting-terminal recipe transfer to the 1.20.4 JEI/Minecraft API boundary.
+- Preserve server-authoritative crafting, slot mapping, ingredient counts, and active-menu validity.
+- Inspect shared JEI handlers, crafting menus, platform recipe abstractions, Gradle JEI versions, and 1.20.6 adapter.
+- Validate compilation and JEI ghost/exact/partial transfer with the integration present.

--- a/Toms-Storage-1204/src/platform-shared/java/com/tom/storagemod/platform/AGENTS.md
+++ b/Toms-Storage-1204/src/platform-shared/java/com/tom/storagemod/platform/AGENTS.md
@@ -1,0 +1,6 @@
+# Minecraft 1.20.4 Abstractions
+
+- Owns mapped recipe, recipe-book button, edit-box, menu, and `SavedData` factory differences shared across loaders.
+- Keep loader APIs out and preserve behavior expected by shared menus, screens, recipes, and remote-link persistence.
+- Inspect final `Platform`, shared GUI/recipe callers, loader remote connections, and adjacent version implementations.
+- Validate recipe lookup/transfer, widget behavior, menu interaction, and save/reload through each consuming loader build.

--- a/Toms-Storage-1204/src/shared/java/AGENTS.md
+++ b/Toms-Storage-1204/src/shared/java/AGENTS.md
@@ -1,0 +1,8 @@
+# Loader-Neutral Java Layer
+
+This layer owns gameplay declarations, blocks, items, menus/screens, synchronization utilities, and recipe-viewer integrations portable across loaders for Minecraft 1.20.4.
+
+- Minecraft and project abstraction imports are allowed; NeoForge and Fabric APIs are not.
+- Cross loader boundaries through `Platform`, `GameObject`, storage interfaces, and existing wrappers.
+- Keep NBT-based item and menu protocols compatible; do not introduce 1.20.6 data components or payload codecs.
+- Validate every consuming loader build when shared behavior changes, plus client/server smoke tests appropriate to the feature.

--- a/Toms-Storage-1204/src/shared/java/com/tom/storagemod/block/AGENTS.md
+++ b/Toms-Storage-1204/src/shared/java/com/tom/storagemod/block/AGENTS.md
@@ -1,0 +1,6 @@
+# Shared Blocks
+
+- Defines terminals, connectors, cables, trims, hoppers, crates, filters, paint behavior, and their interaction contracts.
+- Preserve registry IDs, blockstate properties, shapes, placement/connectivity, menu opening, and block-entity pairing.
+- Inspect `Content`, loader-shared block/tile implementations, item forms, models/blockstates, loot, recipes, tags, and 1.20.6 counterparts.
+- Validate placement/breaking, connectivity, interactions, drops, painting, redstone behavior, and client model logs.

--- a/Toms-Storage-1204/src/shared/java/com/tom/storagemod/emi/AGENTS.md
+++ b/Toms-Storage-1204/src/shared/java/com/tom/storagemod/emi/AGENTS.md
@@ -1,0 +1,6 @@
+# EMI Integration
+
+- Provides crafting-terminal transfer and ghost-ingredient support through EMI's API.
+- Keep optional loading isolated, preserve slot/count mapping, and leave all inventory mutation server-authoritative.
+- Inspect crafting menus/screens, `IDataReceiver`, JEI/REI equivalents, metadata discovery, and Gradle EMI dependencies.
+- Validate startup without EMI and, with EMI present, ghost placement plus exact and partial recipe transfer.

--- a/Toms-Storage-1204/src/shared/java/com/tom/storagemod/gui/AGENTS.md
+++ b/Toms-Storage-1204/src/shared/java/com/tom/storagemod/gui/AGENTS.md
@@ -1,0 +1,6 @@
+# Menus And Screens
+
+- Owns terminal/filter/link/emitter menus and screens, virtual storage slots, controls, and client search/sort behavior.
+- Server menus must validate NBT messages and remain authoritative. Preserve compact keys, slot mapping, shift-click/remainders, incremental sync, and client-only separation.
+- Inspect block entities, network packets, `TerminalSyncManager`, platform GUI adapters, and JEI/REI/EMI handlers before changes.
+- Validate full/partial inventories, shift-click, crafting transfer, filtering, reconnects, sync ordering, malformed packets, and dedicated-server startup.

--- a/Toms-Storage-1204/src/shared/java/com/tom/storagemod/item/AGENTS.md
+++ b/Toms-Storage-1204/src/shared/java/com/tom/storagemod/item/AGENTS.md
@@ -1,0 +1,6 @@
+# Shared Items
+
+- Owns wireless terminals, filters, paint kits, painted block items, and filter interfaces using 1.20.4 item NBT.
+- Preserve NBT keys and equality, binding/range semantics, tooltips, filter modes, paint data, and server-side authorization.
+- Inspect `Content`, loader filter handlers, terminal block entities, GUI, recipes/models/translations, Curios lookup, and 1.20.6 component-based counterparts.
+- Validate NBT save/reload, copied/stacked items, wireless range/dimension rules, filter matching, painting, and Curios absence.

--- a/Toms-Storage-1204/src/shared/java/com/tom/storagemod/jei/AGENTS.md
+++ b/Toms-Storage-1204/src/shared/java/com/tom/storagemod/jei/AGENTS.md
@@ -1,0 +1,6 @@
+# JEI Integration
+
+- Provides JEI discovery, crafting-terminal transfer, and ghost ingredients.
+- Preserve optional loading, menu validity, slot/count mapping, and server-authoritative crafting mutations.
+- Inspect crafting menus/screens, platform-shared JEI adapter, EMI/REI equivalents, metadata, and Gradle JEI dependencies.
+- Validate startup without JEI where supported and, with JEI present, ghost placement plus exact and partial recipe transfer.

--- a/Toms-Storage-1204/src/shared/java/com/tom/storagemod/rei/AGENTS.md
+++ b/Toms-Storage-1204/src/shared/java/com/tom/storagemod/rei/AGENTS.md
@@ -1,0 +1,6 @@
+# REI Integration
+
+- Provides REI crafting-terminal transfer and ghost ingredients when `useLib` enables this package.
+- Do not leak REI classes into unconditional initialization; preserve slot/count mapping and server authority.
+- Inspect loader-shared `REIPlugin_`, crafting menus/screens, JEI/EMI equivalents, and Gradle exclusion/dependency logic.
+- Validate a normal build without `useLib` and `bash gradlew build -DuseLib=true`, then smoke-test transfer with REI present.

--- a/Toms-Storage-1204/src/shared/java/com/tom/storagemod/util/AGENTS.md
+++ b/Toms-Storage-1204/src/shared/java/com/tom/storagemod/util/AGENTS.md
@@ -1,0 +1,6 @@
+# Shared Utilities
+
+- Owns terminal snapshots/synchronization, crafting matrices, player inventory helpers, data slots, priorities, formatting, and shared interfaces.
+- Preserve item NBT equality, incremental-sync ordering, compact message fields, count limits, slot/remainder behavior, and server authority.
+- Inspect GUI callers, network transport, loader storage wrappers/block entities, recipe integrations, and 1.20.6 component-aware equivalents.
+- Validate mixed-NBT stacks, large counts, initial/incremental sync, partial transfers, full player inventory, and crafting remainders.

--- a/Toms-Storage-1204/src/shared/resources/AGENTS.md
+++ b/Toms-Storage-1204/src/shared/resources/AGENTS.md
@@ -1,0 +1,6 @@
+# Shared Resources
+
+- Owns loader-neutral `toms_storage` assets and data: language, textures, models, blockstates, recipes, loot, advancements, tags, and the icon.
+- Preserve registry/resource IDs and dotted filenames. Synchronize content changes with `Content`, blocks/items, menus, painted variants, recipes, loot, tags, and `en_us.json`.
+- Keep loader-specific Curios and NeoForge overlays out of this layer; do not hand-edit generated resources here as a substitute for reviewing `runData` output.
+- Validate resource/data loading, recipes, drops, translations, models/textures, and missing-resource logs on client and server.

--- a/Toms-Storage-1206/AGENTS.md
+++ b/Toms-Storage-1206/AGENTS.md
@@ -1,0 +1,20 @@
+# NeoForge 1.20.6 Project
+
+Inherit repository-wide rules from `../AGENTS.md`; this file covers only Minecraft 1.20.6 on NeoForge 20.6 with Java 21.
+
+## Source Composition
+
+- `main` combines local default `src/main/java` and resources with `src/shared`, `src/loader-shared`, and `src/platform-shared`; all referenced source roots exist locally except the configured but absent `src/platform-shared/resources`.
+- Shared is loader-neutral, loader-shared owns NeoForge-family code, platform-shared isolates 1.20.6 mappings, and main supplies final NeoForge adapters.
+- This port stores important item state in registered data components and uses custom payload types/codecs. Do not replace these with older item-NBT or ad hoc packet-channel patterns; block entities and `SavedData` still retain their defined persistence formats.
+
+## Integrations
+
+- With `useLib` absent, only `com/tom/storagemod/rei/**` is excluded. JEI and EMI source remains compiled and both have runtime dependencies.
+- `-DuseLib=true` enables REI, Cloth Config, and Architectury. Curios has compile and runtime dependencies.
+
+## Commands And Validation
+
+- Run locally: `bash gradlew build`, `bash gradlew runClient`, `bash gradlew runServer`, `bash gradlew runGameTestServer`, and `bash gradlew runData`.
+- The strongest general gate is `bash gradlew build`, followed by client and dedicated-server smoke tests for gameplay, payload, registration, or client changes.
+- Validate optional code both with a normal build and `bash gradlew build -DuseLib=true` when REI-related paths change; inspect generated resource diffs after `runData`.

--- a/Toms-Storage-1206/src/loader-shared/java/AGENTS.md
+++ b/Toms-Storage-1206/src/loader-shared/java/AGENTS.md
@@ -1,0 +1,8 @@
+# NeoForge Loader-Shared Java Layer
+
+This layer owns NeoForge-family lifecycle, configuration, payload registration, capabilities, block entities, storage wrappers, tags, and client model wiring for 1.20.6.
+
+- NeoForge APIs are allowed; Fabric APIs are not. Keep reusable gameplay, components, and payload definitions in `src/shared/java`.
+- Client imports belong behind client initialization or in explicitly client-only classes.
+- Register shared custom payload codecs and data components without changing their IDs or wire/persistence formats.
+- Validate build, client startup, dedicated-server startup, payload registration, and focused inventory behavior.

--- a/Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
+++ b/Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
@@ -1,0 +1,6 @@
+# NeoForge Block Extensions
+
+- Owns framed cable and inventory-proxy blocks that depend on NeoForge behavior.
+- Preserve connection shapes, proxy recursion guards, component-backed paint state, and block-entity pairing.
+- Inspect shared `block`, local `tile`, `Content`, blockstates, models, recipes, loot, and 1.20.4 counterparts.
+- Validate placement/breaking, cable connectivity, proxy capability access, painting, and missing-model logs.

--- a/Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
+++ b/Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
@@ -1,0 +1,6 @@
+# Client Models
+
+- Owns NeoForge baked-model handling for painted blocks.
+- Keep registration client-only and preserve source model transforms, render types, and component-backed paint texture resolution.
+- Inspect `StorageModClient`, painted block/item classes, components, and loader/shared blockstate and model resources together.
+- Validate client startup, resource reload, inventory rendering, placed rendering, and missing-model/texture logs.

--- a/Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
+++ b/Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
@@ -1,0 +1,6 @@
+# Payload Registration
+
+- Registers shared 1.20.6 custom payload types/codecs and binds handlers to the correct network direction and thread context.
+- Preserve payload IDs/codecs, active-menu checks, server authority, and server-side wireless item/range/ownership resolution.
+- Inspect shared `network`, GUI handlers, wireless items, terminal block entities, config, and 1.20.4 channel implementation.
+- Validate client/server registration, codec round trips, malformed payload rejection, terminal actions, wireless/Curios paths, and server startup.

--- a/Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/rei/AGENTS.md
+++ b/Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/rei/AGENTS.md
@@ -1,0 +1,6 @@
+# Optional REI Bootstrap
+
+- Bridges NeoForge discovery to shared REI integration and is compiled only when `useLib` is present.
+- Do not make core or client initialization load REI classes when the package is excluded or REI is absent.
+- Inspect shared `rei`, Gradle exclusions/dependencies, metadata discovery, and adjacent version implementations together.
+- Validate a normal build without `useLib` and `bash gradlew build -DuseLib=true`.

--- a/Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
+++ b/Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
@@ -1,0 +1,6 @@
+# NeoForge Block Entities
+
+- Owns network scanning, item-handler aggregation, terminals, connectors, hoppers, emitters, proxies, and painted block entities.
+- Inventory mutation is server-authoritative. Preserve simulation/remainders, component equality, 20-tick scan limits, cycle detection, persistence keys, loaded checks, and push-or-drop behavior.
+- Inspect shared blocks/items/components/menus/payloads, loader util handlers, `Content`, `Platform`, resources, and 1.20.4 block entities.
+- Validate mixed-component and partial/full transfers, reconnects, filters, recursive networks, wireless range, save/reload, and unloaded remotes.

--- a/Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
+++ b/Toms-Storage-1206/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
@@ -1,0 +1,6 @@
+# NeoForge Storage Utilities
+
+- Owns item-handler wrappers, component-aware filters, aggregate handlers, registry wrappers, remote-link `SavedData`, proxy interfaces, and info hooks.
+- Preserve component equality, simulation/remainders, priority order, recursion limits, `toms_storage_rc` fields, and no-force-load lookup.
+- Inspect block entities, shared components/item/util callers, `Platform`, config, and 1.20.4 NBT-era equivalents.
+- Validate mixed-component stacks, partial transfers, nested handlers, filter modes, priority, world reload, and unloaded channels.

--- a/Toms-Storage-1206/src/loader-shared/resources/AGENTS.md
+++ b/Toms-Storage-1206/src/loader-shared/resources/AGENTS.md
@@ -1,0 +1,6 @@
+# NeoForge Loader-Shared Resources
+
+- Owns NeoForge/Curios-sensitive tags, Curios slot data, and the painted-trim blockstate overlay.
+- Preserve `toms_storage` IDs and dotted filenames; synchronize with loader blocks/items, `Content`, shared models/recipes/loot/translations, and Curios lookup code.
+- Avoid duplicating loader-neutral assets that belong in `src/shared/resources`.
+- Validate data/resource loading, tags, Curios belt behavior, painted trim rendering, and missing-resource logs.

--- a/Toms-Storage-1206/src/main/java/AGENTS.md
+++ b/Toms-Storage-1206/src/main/java/AGENTS.md
@@ -1,0 +1,8 @@
+# Final NeoForge Java Layer
+
+This layer contains final 1.20.6 NeoForge adapters for registration, interactions, item handlers, data components, and container screens.
+
+- NeoForge and mapped 1.20.6 imports are allowed; Fabric imports are not.
+- Keep client-only screen code out of dedicated-server loading paths and reusable logic in higher shared layers.
+- Preserve item-handler simulation/remainders, component registration/codecs, registry IDs, and payload contracts.
+- Validate compilation, client and dedicated-server startup, registration, menu opening, component round trips, and inventory transfers.

--- a/Toms-Storage-1206/src/main/java/com/tom/storagemod/platform/AGENTS.md
+++ b/Toms-Storage-1206/src/main/java/com/tom/storagemod/platform/AGENTS.md
@@ -1,0 +1,6 @@
+# Final Platform Adapters
+
+- Implements NeoForge registration, interaction, item-handler, data-component, recipe, and container-screen requests from shared code.
+- Preserve simulation/remainders, registry IDs, component codecs, sided capability exposure, and client/server class separation.
+- Inspect `Content`, shared components/network, loader block entities/util handlers, platform-shared abstractions, and 1.20.4 adapter before changes.
+- Validate content/component registration, item-state round trips, insert/extract, menu opening, recipe behavior, and both client/server startup.

--- a/Toms-Storage-1206/src/main/resources/AGENTS.md
+++ b/Toms-Storage-1206/src/main/resources/AGENTS.md
@@ -1,0 +1,6 @@
+# Final NeoForge Resources
+
+- Owns 1.20.6 `pack.mcmeta`, `META-INF/neoforge.mods.toml`, and the version-specific access transformer.
+- Keep metadata ranges aligned with `gradle.properties` and mapped access-transformer signatures; do not add guidance files inside `META-INF`.
+- Coordinate metadata class names and optional dependencies with loader initialization, payload/component registration, and Gradle integration behavior.
+- Validate `processResources`/build output, client and dedicated-server discovery, and transformed access at runtime.

--- a/Toms-Storage-1206/src/platform-shared/java/AGENTS.md
+++ b/Toms-Storage-1206/src/platform-shared/java/AGENTS.md
@@ -1,0 +1,8 @@
+# Minecraft 1.20.6 Platform-Shared Java Layer
+
+This layer isolates mapped 1.20.6 recipe, screen-widget, block base, and JEI transfer API differences shared across loaders.
+
+- Minecraft API imports and loader-neutral project abstractions are allowed; NeoForge and Fabric APIs are not.
+- Keep behavior portable across loaders and compatible with 1.20.6 components and payload callers.
+- Compare both loader adapters and adjacent Minecraft-version implementations before changing mapped signatures.
+- Validate every consuming loader build plus focused recipe, screen, block, and integration behavior.

--- a/Toms-Storage-1206/src/platform-shared/java/com/tom/storagemod/jei/AGENTS.md
+++ b/Toms-Storage-1206/src/platform-shared/java/com/tom/storagemod/jei/AGENTS.md
@@ -1,0 +1,6 @@
+# JEI Version Adapter
+
+- Adapts crafting-terminal recipe transfer to the 1.20.6 JEI/Minecraft API boundary.
+- Preserve server-authoritative crafting, component-sensitive ingredients, slot/count mapping, and active-menu validity.
+- Inspect shared JEI handlers, crafting menus, payloads, platform recipe abstractions, Gradle JEI versions, and 1.20.4 adapter.
+- Validate compilation and JEI ghost/exact/partial transfer with component-bearing ingredients and the integration present.

--- a/Toms-Storage-1206/src/platform-shared/java/com/tom/storagemod/platform/AGENTS.md
+++ b/Toms-Storage-1206/src/platform-shared/java/com/tom/storagemod/platform/AGENTS.md
@@ -1,0 +1,6 @@
+# Minecraft 1.20.6 Abstractions
+
+- Owns mapped block base, recipe, recipe-book button, edit-box, and menu differences shared across loaders.
+- Keep loader APIs out and preserve behavior expected by shared blocks, menus, screens, recipes, components, and payload callers.
+- Inspect final `Platform`, shared callers, loader block entities, and adjacent version implementations before mapped changes.
+- Validate block lifecycle, recipe lookup/transfer, widget behavior, and menu interaction through each consuming loader build.

--- a/Toms-Storage-1206/src/shared/java/AGENTS.md
+++ b/Toms-Storage-1206/src/shared/java/AGENTS.md
@@ -1,0 +1,8 @@
+# Loader-Neutral Java Layer
+
+This layer owns gameplay declarations, components, payload definitions, blocks, items, menus/screens, synchronization, and recipe-viewer integrations portable across loaders for Minecraft 1.20.6.
+
+- Minecraft and project abstraction imports are allowed; NeoForge and Fabric APIs are not.
+- Cross loader boundaries through `Platform`, `GameObject`, storage interfaces, and existing wrappers.
+- Use registered data components for defined item state and typed custom payload codecs for network transport; preserve codec compatibility.
+- Validate every consuming loader build when shared behavior changes, plus client/server smoke tests and persistence/network round trips.

--- a/Toms-Storage-1206/src/shared/java/com/tom/storagemod/block/AGENTS.md
+++ b/Toms-Storage-1206/src/shared/java/com/tom/storagemod/block/AGENTS.md
@@ -1,0 +1,6 @@
+# Shared Blocks
+
+- Defines terminals, connectors, cables, trims, hoppers, crates, filters, paint behavior, and their interaction contracts.
+- Preserve registry IDs, blockstate properties, shapes, placement/connectivity, menu opening, and block-entity pairing.
+- Inspect `Content`, loader-shared block/tile implementations, item forms/components, models/blockstates, loot, recipes, tags, and 1.20.4 counterparts.
+- Validate placement/breaking, connectivity, interactions, drops, painting, redstone behavior, and client model logs.

--- a/Toms-Storage-1206/src/shared/java/com/tom/storagemod/components/AGENTS.md
+++ b/Toms-Storage-1206/src/shared/java/com/tom/storagemod/components/AGENTS.md
@@ -1,0 +1,6 @@
+# Item Data Components
+
+- Defines codec-backed filter state used by 1.20.6 items and registered through `Content`/`Platform`.
+- Treat component IDs, codec fields, defaults, equality, and malformed-data behavior as persistence contracts; do not fall back to legacy item NBT.
+- Inspect item/filter consumers, loader filter handlers, `Content`, platform registration, network payloads, and 1.20.4 NBT predecessors.
+- Validate encode/decode round trips, world and inventory reload, copied/stacked items, empty/default state, and malformed persisted data.

--- a/Toms-Storage-1206/src/shared/java/com/tom/storagemod/emi/AGENTS.md
+++ b/Toms-Storage-1206/src/shared/java/com/tom/storagemod/emi/AGENTS.md
@@ -1,0 +1,6 @@
+# EMI Integration
+
+- Provides crafting-terminal transfer and ghost-ingredient support through EMI's API.
+- Keep optional loading isolated, preserve slot/count mapping, and leave inventory mutation server-authoritative through typed payload/menu handling.
+- Inspect crafting menus/screens, network payloads, JEI/REI equivalents, metadata discovery, and Gradle EMI dependencies.
+- Validate startup without EMI where supported and, with EMI present, ghost placement plus exact and partial recipe transfer.

--- a/Toms-Storage-1206/src/shared/java/com/tom/storagemod/gui/AGENTS.md
+++ b/Toms-Storage-1206/src/shared/java/com/tom/storagemod/gui/AGENTS.md
@@ -1,0 +1,6 @@
+# Menus And Screens
+
+- Owns terminal/filter/link/emitter menus and screens, virtual storage slots, controls, and client search/sort behavior.
+- Server menus must validate payload data and remain authoritative. Preserve slot mapping, shift-click/remainders, component equality, incremental sync, and client-only separation.
+- Inspect block entities, shared payloads, `TerminalSyncManager`, platform GUI adapters, and JEI/REI/EMI handlers before changes.
+- Validate full/partial inventories, mixed components, shift-click, crafting transfer, filtering, reconnects, sync ordering, malformed payloads, and server startup.

--- a/Toms-Storage-1206/src/shared/java/com/tom/storagemod/item/AGENTS.md
+++ b/Toms-Storage-1206/src/shared/java/com/tom/storagemod/item/AGENTS.md
@@ -1,0 +1,6 @@
+# Shared Items
+
+- Owns wireless terminals, filters, paint kits, painted block items, and filter interfaces using registered 1.20.6 data components.
+- Preserve component IDs/codecs and equality, binding/range semantics, tooltips, filter modes, paint data, and server-side authorization.
+- Inspect `Content`, shared components, loader filter handlers, terminal block entities, GUI/payloads, resources, Curios lookup, and 1.20.4 NBT predecessors.
+- Validate component save/reload and copies, mixed-component stacks, wireless range/dimension rules, filter matching, painting, and Curios paths.

--- a/Toms-Storage-1206/src/shared/java/com/tom/storagemod/jei/AGENTS.md
+++ b/Toms-Storage-1206/src/shared/java/com/tom/storagemod/jei/AGENTS.md
@@ -1,0 +1,6 @@
+# JEI Integration
+
+- Provides JEI discovery, crafting-terminal transfer, and ghost ingredients.
+- Preserve optional loading, active-menu validity, slot/count mapping, and server-authoritative mutation through the payload/menu path.
+- Inspect crafting menus/screens, shared network payloads, platform-shared JEI adapter, EMI/REI equivalents, metadata, and Gradle dependencies.
+- Validate startup without JEI where supported and, with JEI present, ghost placement plus exact and partial recipe transfer.

--- a/Toms-Storage-1206/src/shared/java/com/tom/storagemod/network/AGENTS.md
+++ b/Toms-Storage-1206/src/shared/java/com/tom/storagemod/network/AGENTS.md
@@ -1,0 +1,6 @@
+# Typed Payloads
+
+- Defines loader-neutral 1.20.6 custom payload records/types/codecs for terminal data and wireless open requests.
+- Treat payload IDs, codec order/types, bounds, and menu dispatch as cross-side contracts. Validate all client input server-side and never trust positions, counts, ownership, or range.
+- Inspect loader-shared `NetworkHandler`, GUI send/receive sites, wireless items, terminal block entities, and 1.20.4 NBT packet predecessors.
+- Validate codec round trips, malformed/truncated data, wrong-menu rejection, terminal actions, wireless authorization, and client/server version agreement.

--- a/Toms-Storage-1206/src/shared/java/com/tom/storagemod/rei/AGENTS.md
+++ b/Toms-Storage-1206/src/shared/java/com/tom/storagemod/rei/AGENTS.md
@@ -1,0 +1,6 @@
+# REI Integration
+
+- Provides REI crafting-terminal transfer and ghost ingredients when `useLib` enables this package.
+- Do not leak REI classes into unconditional initialization; preserve slot/count mapping and server authority through typed payloads.
+- Inspect loader-shared `REIPlugin_`, crafting menus/screens, network payloads, JEI/EMI equivalents, and Gradle exclusion/dependency logic.
+- Validate a normal build without `useLib` and `bash gradlew build -DuseLib=true`, then smoke-test transfer with REI present.

--- a/Toms-Storage-1206/src/shared/java/com/tom/storagemod/util/AGENTS.md
+++ b/Toms-Storage-1206/src/shared/java/com/tom/storagemod/util/AGENTS.md
@@ -1,0 +1,6 @@
+# Shared Utilities
+
+- Owns component-aware terminal snapshots/sync, crafting matrices, player inventory helpers, data slots, priorities, formatting, and shared interfaces.
+- Preserve component equality, incremental-sync ordering, payload fields, count limits, slot/remainder behavior, and server authority.
+- Inspect GUI callers, shared payload codecs, loader storage wrappers/block entities, recipe integrations, and 1.20.4 NBT-era equivalents.
+- Validate mixed-component stacks, large counts, initial/incremental sync, partial transfers, full player inventory, and crafting remainders.

--- a/Toms-Storage-1206/src/shared/resources/AGENTS.md
+++ b/Toms-Storage-1206/src/shared/resources/AGENTS.md
@@ -1,0 +1,6 @@
+# Shared Resources
+
+- Owns loader-neutral `toms_storage` assets and data: language, textures, models, blockstates, recipes, loot, advancements, tags, and the icon.
+- Preserve registry/resource IDs and dotted filenames. Synchronize content/component changes with `Content`, blocks/items, menus, painted variants, recipes, loot, tags, and `en_us.json`.
+- Keep loader-specific Curios and NeoForge overlays out of this layer; review rather than blindly accept `runData` output.
+- Validate resource/data loading, component-backed item models/tooltips, recipes, drops, translations, models/textures, and missing-resource logs.

--- a/Toms-Storage-Fabric-1.20.2/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.2/AGENTS.md
@@ -1,0 +1,7 @@
+# Fabric 1.20.2 Project
+
+- Target Minecraft 1.20.2 with Fabric Loader 0.14.22, Fabric API 0.89.0+1.20.2, and Java 17 (`--release 17`).
+- This is an inherited bridge: local code only adapts the platform and metadata while `sourceSets` expects 1.20.1 shared/loader code and 1.20.2 platform-shared code.
+- All configured no-hyphen siblings are absent: `../TomsStorage-120`, `../TomsStorageFabric-1.20`, and `../TomsStorage-1202`. Gradle may omit them silently, so do not trust results until every path exists.
+- Only after source-layout validation, run commands here: `bash gradlew build`, then `bash gradlew runClient` and `bash gradlew runServer` for bridge or networking changes.
+- Strongest validation is a build that demonstrably includes all inherited sources, plus client/server smoke tests, legacy NBT packet/menu tests, and save/reload tests.

--- a/Toms-Storage-Fabric-1.20.2/src/main/java/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.2/src/main/java/AGENTS.md
@@ -1,0 +1,6 @@
+# Main Java Layer
+
+- This layer contains only final Minecraft 1.20.2 Fabric adapters over inherited 1.20.1 shared/loader code and 1.20.2 platform-shared code.
+- Fabric API, Fabric Loader, and Trinkets calls may be used here; do not push mapped 1.20.2 details into inherited common contracts.
+- Preserve the legacy NBT protocol while adapting changed Minecraft signatures such as bounded NBT reads.
+- Validate only after inherited source paths resolve; then test compilation, dedicated-server class loading, registration, menus, NBT sync, and Trinkets-present/absent behavior.

--- a/Toms-Storage-Fabric-1.20.2/src/main/java/com/tom/storagemod/platform/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.2/src/main/java/com/tom/storagemod/platform/AGENTS.md
@@ -1,0 +1,6 @@
+# Platform Package
+
+- Bridges inherited 1.20.1 Fabric/common behavior to Minecraft 1.20.2 registries, interactions, bounded NBT reads, Trinkets, and screens.
+- Preserve registry IDs, nullable/PASS interaction semantics, server authority, NBT identity, and optional Trinkets loading; do not introduce 1.20.4 or data-component APIs.
+- Related code is expected from `TomsStorage-120`, `TomsStorageFabric-1.20`, and `TomsStorage-1202`; all are configured no-hyphen siblings and absent in this checkout.
+- Validate the complete composed source set, NBT packet decoding, menu opening, registrations, and wireless lookup with and without Trinkets.

--- a/Toms-Storage-Fabric-1.20.2/src/main/resources/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.2/src/main/resources/AGENTS.md
@@ -1,0 +1,6 @@
+# Main Resources
+
+- Owns the 1.20.2 bridge's `fabric.mod.json`, mapped access widener, and pack metadata; loader-shared assets/data are expected from `TomsStorageFabric-1.20`.
+- Keep entry points and optional REI/EMI/JEI declarations synchronized with inherited classes, and keep access-widened recipe-book/slot members valid for 1.20.2 mappings.
+- Coordinate metadata with inherited Trinkets data, tags, and painted models; preserve IDs and verify that no missing sibling resource layer was silently omitted.
+- Validate built-JAR contents, metadata expansion, client/server startup, access widening, optional integrations, Trinkets wireless access, tags, and models.

--- a/Toms-Storage-Fabric-1.20.4/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.4/AGENTS.md
@@ -1,0 +1,7 @@
+# Fabric 1.20.4 Project
+
+- Target Minecraft 1.20.4 with Fabric Loader 0.15.6, Fabric API 0.95.0+1.20.4, and Java 17 (`--release 17`).
+- This line has local Fabric loader code but retains legacy raw-channel `FriendlyByteBuf`/NBT play networking and NBT item persistence.
+- `sourceSets` expects absent no-hyphen sibling `../TomsStorage-1204` for shared and platform-shared Java and resources. Do not trust Gradle results until every configured source directory exists.
+- Only after source-layout validation, run commands here: `bash gradlew build`, then `bash gradlew runClient` and `bash gradlew runServer` for gameplay or networking changes.
+- Strongest validation is a complete build plus client/server smoke tests; transfer changes require transaction edge cases and persistence changes require save/reload and sync tests.

--- a/Toms-Storage-Fabric-1.20.4/src/loader-shared/java/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.4/src/loader-shared/java/AGENTS.md
@@ -1,0 +1,6 @@
+# Loader-Shared Java Layer
+
+- This is the Minecraft 1.20.4 Fabric layer for lifecycle, legacy networking, Transfer API storage, block entities, models, configuration, and tags.
+- Fabric API and loader-family integrations belong here; intended shared gameplay and platform-shared abstractions must remain free of Fabric imports.
+- Preserve raw packet channel IDs, NBT payload shape, transaction semantics, and client/server class-loading boundaries.
+- Compare changes with intended `TomsStorage-1204` common/platform code and the final local `platform` adapter; first prove all source roots are included.

--- a/Toms-Storage-Fabric-1.20.4/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.4/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
@@ -1,0 +1,6 @@
+# Block Package
+
+- Provides Fabric-specific framed/painted cable and inventory-proxy block behavior for 1.20.4.
+- Preserve block/entity IDs, placement state, painted NBT, server-authoritative mutation, and sided storage exposure; never lose or duplicate contents.
+- Related behavior is in intended `TomsStorage-1204` common blocks/resources, local `tile` entities, and final `platform` registration.
+- Validate placement/break drops, painting, proxy direction, block-state models, and client/server interaction.

--- a/Toms-Storage-Fabric-1.20.4/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.4/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
@@ -1,0 +1,6 @@
+# Model Package
+
+- Implements Fabric client baked-model handling for painted 1.20.4 blocks.
+- Keep rendering code out of server initialization and synchronize model IDs/variants with loader-shared blockstates and intended common models.
+- Related code is `StorageModClient`, painted blocks/entities, and the intended common/platform model hooks.
+- Validate client launch and resource reload, every painted variant, missing-model/texture logs, and dedicated-server startup.

--- a/Toms-Storage-Fabric-1.20.4/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.4/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
@@ -1,0 +1,6 @@
+# Network Package
+
+- Sends legacy 1.20.4 play traffic on stable raw `ResourceLocation` channels using `FriendlyByteBuf` and `CompoundTag` payloads.
+- Preserve packet IDs and compact NBT keys; validate the active server menu and reject untrusted client counts, slots, positions, ownership, and channel data.
+- Related receivers are in `StorageMod`; intended common menus and `IDataReceiver` define payload meaning, while `platform` handles mapped NBT reads.
+- Validate click/search traffic, terminal sync, stale menu state, wireless open, reconnect, malformed data, and dedicated-server startup.

--- a/Toms-Storage-Fabric-1.20.4/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.4/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
@@ -1,0 +1,6 @@
+# Tile Package
+
+- Implements 1.20.4 Fabric Transfer API entities for connectors, terminals, hoppers, crates, proxies, emitters, crafting, and painting.
+- Preserve transaction atomicity, simulation/remainders, sided access, cycle checks, loaded-chunk guards, server authority, and persisted NBT keys.
+- Related common block/menu logic is intended from `TomsStorage-1204`; local `util` wrappers and `block` classes form the Fabric boundary.
+- Validate full/partial transfers, filters, recursive networks, disconnects, wireless access, chunk unloads, and save/reload.

--- a/Toms-Storage-Fabric-1.20.4/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.4/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
@@ -1,0 +1,6 @@
+# Util Package
+
+- Supplies 1.20.4 Fabric Transfer API wrappers, merged/filtered storage, predicates, registrations, proxy resolution, and remote-link `SavedData`.
+- Preserve transaction context, exact amounts, view identity, filter semantics, recursion guards, `toms_storage_rc` fields, and no force-loading during remote lookup.
+- Related consumers are local connector/terminal entities; intended common item/menu contracts and final `platform` adapters must remain compatible.
+- Validate nested/filtered storage, full inventories, rollback/simulation, duplicate networks, ownership/visibility, unloaded endpoints, and persistence.

--- a/Toms-Storage-Fabric-1.20.4/src/loader-shared/resources/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.4/src/loader-shared/resources/AGENTS.md
@@ -1,0 +1,6 @@
+# Loader Resources
+
+- Contains 1.20.4 Fabric painted blockstates/models, recipes/loot, tags, and Trinkets entity and belt-slot data.
+- Keep IDs synchronized with Java registrations, intended common assets/data, and main `fabric.mod.json`; keep Trinkets resources aligned with optional wireless lookup.
+- Coordinate entry-point or widened-member changes with main metadata/access widener; mapped names are version-specific.
+- Validate client resource loading and missing-model logs, recipes/loot/tags, Trinkets-equipped wireless access, and server data-pack loading.

--- a/Toms-Storage-Fabric-1.20.4/src/main/java/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.4/src/main/java/AGENTS.md
@@ -1,0 +1,6 @@
+# Main Java Layer
+
+- This layer contains final Minecraft 1.20.4 Fabric adapters, not common gameplay or loader lifecycle code.
+- Fabric API, Fabric Loader, and Trinkets calls may be used here; do not leak them into inherited shared or platform-shared contracts.
+- Keep client screen helpers client-only and preserve legacy NBT sync while adapting mapped Minecraft signatures.
+- Validate compilation, dedicated-server class loading, menus, registry/item-group behavior, NBT reads, and Trinkets-present/absent behavior.

--- a/Toms-Storage-Fabric-1.20.4/src/main/java/com/tom/storagemod/platform/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.4/src/main/java/com/tom/storagemod/platform/AGENTS.md
@@ -1,0 +1,6 @@
+# Platform Package
+
+- Implements final 1.20.4 Fabric registries, item groups, block-use hooks, bounded NBT reads, Trinkets lookup, and screens.
+- Preserve IDs, nullable/PASS interaction semantics, NBT identity, server authority, and optional Trinkets loading; transfer callers must retain transaction and remainder semantics.
+- Related code lives in local loader-shared lifecycle/storage classes and intended `TomsStorage-1204` shared/platform counterparts.
+- Validate registrations and menus on client/server, legacy NBT round trips, and wireless lookup both with and without Trinkets.

--- a/Toms-Storage-Fabric-1.20.4/src/main/resources/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.4/src/main/resources/AGENTS.md
@@ -1,0 +1,6 @@
+# Main Resources
+
+- Owns 1.20.4 `fabric.mod.json`, `tomsstorage.accesswidener`, and pack metadata.
+- Keep entry points and optional REI/EMI/JEI declarations synchronized with compiled classes; keep the mapped recipe-book/slot access widener synchronized with Loom.
+- Coordinate metadata with loader-shared Trinkets data, tags, and painted models; preserve IDs and do not broaden compatibility without testing.
+- Validate expanded built-JAR metadata, client/server startup, access widening, optional integrations, Trinkets behavior, and resource loading.

--- a/Toms-Storage-Fabric-1.20.6/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.6/AGENTS.md
@@ -1,0 +1,7 @@
+# Fabric 1.20.6 Project
+
+- Target Minecraft 1.20.6 with Fabric Loader 0.15.11 and Fabric API 0.98.0+1.20.6.
+- Gradle declares Java 21 source/target but forces every Java compile to `--release 17`; resolve this conflict before using Java 21 syntax or claiming a Java-level validation.
+- This line uses data components for important item state and Fabric custom payload types/stream codecs, while packet bodies still carry compact NBT where defined.
+- `sourceSets` expects absent no-hyphen sibling `../TomsStorage-1206` for shared and platform-shared Java/resources. Validate every configured path before running local `bash gradlew build`, `bash gradlew runClient`, or `bash gradlew runServer`.
+- Strongest validation is a complete composed build plus client/server payload tests, transfer edge cases, component-preserving sync, and world/item save-reload compatibility.

--- a/Toms-Storage-Fabric-1.20.6/src/loader-shared/java/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.6/src/loader-shared/java/AGENTS.md
@@ -1,0 +1,6 @@
+# Loader-Shared Java Layer
+
+- This is the Minecraft 1.20.6 Fabric layer for lifecycle, custom payload registration, Transfer API storage, block entities, components, models, config, and tags.
+- Fabric API and loader integrations belong here; intended shared gameplay and platform-shared abstractions must remain free of Fabric imports.
+- Register payload types before receivers, preserve stream codecs/IDs and server authority, and preserve component-aware item identity and transaction semantics.
+- Resolve Java 21 versus `--release 17`; compare with intended `TomsStorage-1206` counterparts and prove source inclusion before validation.

--- a/Toms-Storage-Fabric-1.20.6/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.6/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
@@ -1,0 +1,6 @@
+# Block Package
+
+- Provides 1.20.6 Fabric framed/painted cable and inventory-proxy block behavior and component-era block-entity handoff.
+- Preserve IDs, placement state, serialized painted data, component-bearing stacks, server authority, and sided storage exposure; never lose or duplicate contents.
+- Related behavior is in intended `TomsStorage-1206` common blocks/resources, local `tile` entities, and final component-aware `platform` registration.
+- Validate placement/break with component-bearing items, painting, proxy direction, models, save/reload, and client/server interaction.

--- a/Toms-Storage-Fabric-1.20.6/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.6/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
@@ -1,0 +1,6 @@
+# Model Package
+
+- Implements Fabric client baked-model handling for painted 1.20.6 blocks.
+- Keep rendering code out of server initialization and synchronize model IDs/variants with loader blockstates and intended common models.
+- Related code is `StorageModClient`, painted blocks/entities, component-bearing item displays, and intended common/platform model hooks.
+- Validate client launch/resource reload, painted variants and component-bearing stacks, missing-model logs, and dedicated-server startup.

--- a/Toms-Storage-Fabric-1.20.6/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.6/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
@@ -1,0 +1,6 @@
+# Network Package
+
+- Sends 1.20.6 `CustomPacketPayload` records registered through `PayloadTypeRegistry`, with stable IDs and stream codecs; `DataPacket` semantics still use compact NBT.
+- Register codecs on the correct S2C/C2S side before receivers; validate active menus and reject untrusted client counts, slots, positions, ownership, and channel data.
+- Related payload records and `IDataReceiver` contracts are in intended common code; `StorageMod` owns registration/receivers and `platform` supports mapped buffer reads.
+- Validate codec round trips, click/search and terminal sync, stale menus, wireless open, reconnect, malformed data, and dedicated-server startup.

--- a/Toms-Storage-Fabric-1.20.6/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.6/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
@@ -1,0 +1,6 @@
+# Tile Package
+
+- Implements 1.20.6 Fabric Transfer API entities for connectors, terminals, hoppers, crates, proxies, emitters, crafting, painting, and component-era persistence.
+- Preserve transaction atomicity, exact remainders, component-aware `ItemVariant` equality, sided access, cycle checks, loaded-chunk guards, server authority, and persisted keys.
+- Related common block/menu/component logic is intended from `TomsStorage-1206`; local `util` wrappers and `block` classes form the Fabric boundary.
+- Validate partial/full transfers of component-distinct stacks, filters, recursion, disconnects, wireless access, chunk unloads, and save/reload.

--- a/Toms-Storage-Fabric-1.20.6/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.6/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
@@ -1,0 +1,6 @@
+# Util Package
+
+- Supplies 1.20.6 Fabric Transfer API wrappers, component-aware filters, merged storage, registrations, proxy resolution, and remote-link `SavedData`.
+- Preserve transaction context, exact amounts, component-aware `ItemVariant` identity, filter/cycle semantics, `toms_storage_rc` fields, and no force-loading during lookup.
+- Related consumers are connector/terminal entities; intended common component/menu codecs and final `platform` registration must remain compatible.
+- Validate component-distinct stacks, nested/filtered storage, rollback/simulation, duplicate networks, ownership/visibility, unloaded endpoints, and persistence.

--- a/Toms-Storage-Fabric-1.20.6/src/loader-shared/resources/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.6/src/loader-shared/resources/AGENTS.md
@@ -1,0 +1,6 @@
+# Loader Resources
+
+- Contains 1.20.6 Fabric painted blockstates/models, loot, common-namespace item tags, Minecraft tags, and Trinkets entity/slot data.
+- Keep IDs synchronized with Java/component registrations, intended common assets/data, and main `fabric.mod.json`; keep Trinkets resources aligned with optional wireless lookup.
+- Coordinate payload entry-point or widened-member changes with main metadata/access widener; never copy mapped members or tag conventions from older versions blindly.
+- Validate client models and component-bearing item display, server tag/data loading, loot, Trinkets wireless access, and missing-resource logs.

--- a/Toms-Storage-Fabric-1.20.6/src/main/java/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.6/src/main/java/AGENTS.md
@@ -1,0 +1,6 @@
+# Main Java Layer
+
+- This layer contains final Minecraft 1.20.6 Fabric adapters, including data-component registration support, not common gameplay implementations.
+- Fabric API, Fabric Loader, and Trinkets calls may be used here; do not leak them into inherited shared/platform contracts.
+- Preserve component identity through registry, item, sync, and optional-slot paths; do not reintroduce legacy item-tag assumptions.
+- Resolve Java 21 versus `--release 17` before new language/API use; validate client/server loading, menus, registrations, components, and Trinkets absence.

--- a/Toms-Storage-Fabric-1.20.6/src/main/java/com/tom/storagemod/platform/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.6/src/main/java/com/tom/storagemod/platform/AGENTS.md
@@ -1,0 +1,6 @@
+# Platform Package
+
+- Implements final 1.20.6 Fabric registries, including data-component types, item groups, use hooks, Trinkets lookup, NBT-buffer compatibility, and screens.
+- Preserve IDs, component values, nullable/PASS interaction semantics, server authority, and optional Trinkets loading; transfer callers must preserve transactions and exact amounts.
+- Related code lives in local loader-shared lifecycle/storage code and intended `TomsStorage-1206` shared/platform component and menu contracts.
+- Validate component registration and round trips, client/server menus, wireless lookup with/without Trinkets, and compilation under the resolved Java target.

--- a/Toms-Storage-Fabric-1.20.6/src/main/resources/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20.6/src/main/resources/AGENTS.md
@@ -1,0 +1,6 @@
+# Main Resources
+
+- Owns 1.20.6 `fabric.mod.json`, `tomsstorage.accesswidener`, and pack metadata.
+- Keep entry points and optional REI/EMI/JEI declarations synchronized with payload/component-aware classes; keep mapped recipe-book/slot widening synchronized with Loom.
+- Coordinate metadata with loader-shared Trinkets data, tags, and painted models; preserve IDs and do not broaden compatibility without testing.
+- Validate expanded built-JAR metadata, client/server startup, access widening, payload entry points, optional integrations, Trinkets behavior, and resources.

--- a/Toms-Storage-Fabric-1.20/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20/AGENTS.md
@@ -1,0 +1,7 @@
+# Fabric 1.20.1 Project
+
+- Target Minecraft 1.20.1 with Fabric Loader 0.16.10, Fabric API 0.92.3+1.20.1, and Java 17 (`--release 17`).
+- This is the legacy Fabric implementation: gameplay item state and play packets use NBT; networking uses raw `ResourceLocation` channels and `FriendlyByteBuf`.
+- `sourceSets` expects absent no-hyphen sibling `../TomsStorage-120` for shared and platform-shared Java and resources. Do not trust Gradle results until every configured source directory exists.
+- Only after source-layout validation, run commands here: `bash gradlew build`, then `bash gradlew runClient` and `bash gradlew runServer` for gameplay or networking changes.
+- Strongest validation is a complete build plus client/server smoke tests; transfer changes also require partial/full insert and extract tests, and NBT changes require save/reload and client sync tests.

--- a/Toms-Storage-Fabric-1.20/src/loader-shared/java/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20/src/loader-shared/java/AGENTS.md
@@ -1,0 +1,6 @@
+# Loader-Shared Java Layer
+
+- This is the Minecraft 1.20.1 Fabric implementation layer for lifecycle, legacy networking, Transfer API storage, block entities, models, configuration, and tags.
+- Fabric API and loader-family integrations belong here; shared gameplay and platform-shared abstractions must remain free of Fabric imports.
+- Preserve raw channel IDs, NBT packet shape, transaction commit/simulation behavior, and dedicated-server separation.
+- Compare changes with the intended `TomsStorage-120` common/platform layers and the final local `platform` adapter; validate build inclusion before relying on tests.

--- a/Toms-Storage-Fabric-1.20/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
@@ -1,0 +1,6 @@
+# Block Package
+
+- Provides Fabric-specific framed/painted cable and inventory-proxy block behavior and bridges interactions to block entities.
+- Preserve block/entity registration IDs, placement state, painted NBT, server-authoritative mutation, and sided storage exposure; never lose or duplicate inventory contents.
+- Related behavior is in intended `TomsStorage-120` common blocks/resources, local `tile` entities, and final `platform` registration.
+- Validate placement/break drops, painting, proxy direction, block-state models, and client/server interaction.

--- a/Toms-Storage-Fabric-1.20/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
@@ -1,0 +1,6 @@
+# Model Package
+
+- Implements Fabric client baked-model handling for painted blocks.
+- Keep rendering code out of server initialization and synchronize model IDs and variants with loader-shared blockstates and inherited common models.
+- Related code is `StorageModClient`, painted blocks/entities, and the intended common/platform model hooks.
+- Validate a client launch, resource reload, every painted variant, and logs for missing models or textures; also smoke-test a dedicated server.

--- a/Toms-Storage-Fabric-1.20/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
@@ -1,0 +1,6 @@
+# Network Package
+
+- Sends legacy 1.20.1 play traffic on stable raw `ResourceLocation` channels using `FriendlyByteBuf` and `CompoundTag` payloads.
+- Preserve packet IDs and compact NBT keys; validate the active server menu and never trust client counts, slots, positions, ownership, or channel data.
+- Related receivers are registered by `StorageMod`; common menus and `IDataReceiver` define payload meaning, while `platform` provides NBT buffer compatibility.
+- Validate client-to-server clicks/search, server-to-client terminal sync, malformed/stale menu state, wireless open, reconnect, and dedicated-server startup.

--- a/Toms-Storage-Fabric-1.20/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
@@ -1,0 +1,6 @@
+# Tile Package
+
+- Implements Fabric Transfer API block entities for connectors, terminals, hoppers, crates, proxies, emitters, crafting state, and painted state.
+- Preserve transaction atomicity, simulation/remainders, sided access, cycle checks, loaded-chunk guards, server authority, and all persisted NBT keys.
+- Related common block/menu logic comes from intended `TomsStorage-120`; local `util` wrappers and `block` classes provide the Fabric storage boundary.
+- Validate full/partial insert and extract, filtered and recursive networks, disconnects, wireless access, chunk unloads, and save/reload.

--- a/Toms-Storage-Fabric-1.20/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
@@ -1,0 +1,6 @@
+# Util Package
+
+- Supplies Fabric Transfer API wrappers, merged/filtered storage, predicates, registrations, proxy resolution, and remote-link `SavedData`.
+- Preserve transaction context, exact accepted amounts, view identity, filter semantics, recursion guards, `toms_storage_rc` fields, and the rule that remote lookup never force-loads chunks.
+- Related consumers are local connector/terminal entities; common item/menu contracts and final `platform` adapters must remain compatible.
+- Validate nested and filtered storage, full inventories, rollback/simulation, duplicate networks, channel ownership/visibility, unloaded endpoints, and persistence round trips.

--- a/Toms-Storage-Fabric-1.20/src/loader-shared/resources/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20/src/loader-shared/resources/AGENTS.md
@@ -1,0 +1,6 @@
+# Loader Resources
+
+- Contains Fabric-only painted blockstates/models, recipes/loot, item/block tags, and Trinkets entity and belt-slot data for 1.20.1.
+- Keep IDs synchronized with Java registrations, inherited common assets/data, and `src/main/resources/fabric.mod.json`; keep Trinkets resources aligned with optional wireless-slot lookup.
+- If entry points or widened members change, update `fabric.mod.json` or the mapped access widener in main resources together; do not copy mappings from another Minecraft version.
+- Validate JSON/resource loading in a client, missing-model logs, recipes/loot/tags, Trinkets-equipped wireless access, and a server data-pack load.

--- a/Toms-Storage-Fabric-1.20/src/main/java/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20/src/main/java/AGENTS.md
@@ -1,0 +1,6 @@
+# Main Java Layer
+
+- This layer contains final Minecraft 1.20.1 Fabric adapters, not shared gameplay implementations.
+- Fabric API, Fabric Loader, and Trinkets calls may be used here; do not leak them into the inherited shared or platform-shared contracts.
+- Keep client screen helpers client-only and keep registry, interaction, NBT buffer, and extra-slot behavior aligned with the loader-shared entry points.
+- Validate compilation, dedicated-server class loading, menu opening, creative-tab registration, and Trinkets-present/absent behavior.

--- a/Toms-Storage-Fabric-1.20/src/main/java/com/tom/storagemod/platform/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20/src/main/java/com/tom/storagemod/platform/AGENTS.md
@@ -1,0 +1,6 @@
+# Platform Package
+
+- Implements the final Fabric registry, item-group, block-use, legacy NBT sync-buffer, Trinkets lookup, and container-screen adapters requested by common code.
+- Preserve registry IDs, nullable/PASS interaction semantics, server authority, NBT identity, and optional Trinkets loading; transfer operations must preserve simulation and remainders.
+- Related code lives in loader-shared `StorageMod`, `GameObject`, and storage wrappers, plus the intended `TomsStorage-120` shared/platform counterparts configured by `sourceSets`.
+- Validate registrations and menus on client/server, NBT round trips, and wireless lookup both with and without Trinkets.

--- a/Toms-Storage-Fabric-1.20/src/main/resources/AGENTS.md
+++ b/Toms-Storage-Fabric-1.20/src/main/resources/AGENTS.md
@@ -1,0 +1,6 @@
+# Main Resources
+
+- Owns 1.20.1 `fabric.mod.json`, `tomsstorage.accesswidener`, and pack metadata.
+- Keep entry points and optional REI/EMI/JEI declarations synchronized with compiled classes; keep the access-widener filename and mapped recipe-book/slot members synchronized with Loom.
+- Coordinate metadata with loader-shared Trinkets data, tags, and painted models; preserve `toms_storage` IDs and do not broaden Minecraft ranges without testing.
+- Validate expanded metadata in the built JAR, client and dedicated-server startup, access-widener application, optional integrations, Trinkets behavior, and resource loading.

--- a/Toms-Storage-LexForge-1202/AGENTS.md
+++ b/Toms-Storage-LexForge-1202/AGENTS.md
@@ -1,0 +1,9 @@
+# Legacy Forge 1.20.2 Project
+
+Inherit repository rules from `../AGENTS.md`. This is the legacy Minecraft 1.20.2 Forge 48.1.0 compatibility port and targets Java 17; it is not the NeoForge 1.20.2 project.
+
+- Default `src/main` is local. Configured shared Java/resources come from `../TomsStorage-120`, and platform Java/resources from `../TomsStorage-1202`; those no-hyphen siblings are absent in this checkout, so inherited code is omitted and validation is blocked.
+- Run commands here: `bash gradlew tasks` to identify renamed run tasks and `bash gradlew build` only after verifying every source-set path exists. Do not create symlinks or rewrite paths unless that is the task.
+- Omitting JVM property `-DuseLib` excludes inherited `com/tom/storagemod/rei/**`; any present value enables REI/Cloth/Architectury. JEI and EMI are otherwise inherited without exclusions.
+- Strongest validation is a source-path audit, `bash gradlew build`, then affected client and dedicated-server smoke tests. A build that omitted absent inherited sources is not evidence of correctness.
+- Preserve Forge 1.20.2 mappings, NBT and packet contracts, and registry/resource IDs; compare the Forge 1.20.1 source owner and the separate NeoForge 1.20.2 port deliberately.

--- a/Toms-Storage-LexForge-1202/src/main/java/AGENTS.md
+++ b/Toms-Storage-LexForge-1202/src/main/java/AGENTS.md
@@ -1,0 +1,7 @@
+# Final Legacy Forge Java Layer
+
+This local layer owns the final Minecraft 1.20.2 Forge channel and platform adapters; gameplay and loader-family code are intended to arrive from configured sibling overlays.
+
+- Forge 1.20.2 APIs are allowed; NeoForge and Fabric APIs are not. Keep reusable behavior in its actual shared owner rather than duplicating it here.
+- The configured no-hyphen shared/platform siblings are absent, so inspect `build.gradle` and compare hyphenated Forge 1.20.1 and NeoForge 1.20.2 counterparts without assuming either is compiled.
+- Preserve packet discriminators, registry IDs, capability semantics, mapped signatures, and client/server class separation.

--- a/Toms-Storage-LexForge-1202/src/main/java/com/tom/storagemod/network/AGENTS.md
+++ b/Toms-Storage-LexForge-1202/src/main/java/com/tom/storagemod/network/AGENTS.md
@@ -1,0 +1,7 @@
+# Legacy Forge Network Adapter
+
+Own the Forge 1.20.2 `SimpleChannel`, packet registration, `DataPacket` serialization, and server dispatch.
+
+- Preserve channel ID/version, discriminator order, compact NBT keys, direction/enqueue behavior, active-menu checks, and server authority.
+- Inspect the Forge 1.20.1 and NeoForge 1.20.2 adapters plus the intended inherited `OpenTerminalPacket`, menus, and `IDataReceiver`; account for the missing sibling composition.
+- After restoring valid sources, validate malformed/stale menu packets, terminal and crafting actions, wireless opening, client/server compatibility, and dedicated-server startup.

--- a/Toms-Storage-LexForge-1202/src/main/java/com/tom/storagemod/platform/AGENTS.md
+++ b/Toms-Storage-LexForge-1202/src/main/java/com/tom/storagemod/platform/AGENTS.md
@@ -1,0 +1,7 @@
+# Legacy Forge Platform Adapter
+
+Own Forge 1.20.2 registries, creative tab, capability and interaction helpers, menus, screens, and final mapped platform behavior.
+
+- Preserve historical registry IDs, registration timing, capability invalidation, interaction results, menu payloads, and sided class loading.
+- Inspect Forge 1.20.1 and NeoForge 1.20.2 platform counterparts plus intended inherited `Content`, loader utilities, platform helpers, and resources; do not guess across mappings.
+- After restoring valid sources, validate registration, creative entries, menus/screens, capability exposure, block interactions, and client plus dedicated-server launch.

--- a/Toms-Storage-LexForge-1202/src/main/resources/AGENTS.md
+++ b/Toms-Storage-LexForge-1202/src/main/resources/AGENTS.md
@@ -1,0 +1,7 @@
+# Legacy Forge 1.20.2 Resources
+
+Own local `pack.mcmeta`, Forge metadata, and access-transformer inputs; common assets/data are intended to come from absent configured sibling layers.
+
+- Keep `mods.toml`, Forge/Minecraft ranges, mod ID, and mapped access-transformer signatures aligned with exact Minecraft 1.20.2 Forge behavior.
+- Synchronize metadata and transformer changes with local adapters and inherited registrations/resources once source composition is valid; do not add guides inside `META-INF`.
+- Validate source paths first, then `bash gradlew build`, packaged resource contents, client metadata loading, and dedicated-server transformer behavior.

--- a/Toms-Storage-LexForge-1204/AGENTS.md
+++ b/Toms-Storage-LexForge-1204/AGENTS.md
@@ -1,0 +1,9 @@
+# Legacy Forge 1.20.4 Project
+
+Inherit repository rules from `../AGENTS.md`. This is the legacy Minecraft 1.20.4 Forge 49.0.13 compatibility port and targets Java 17; it is not the NeoForge 1.20.4 project.
+
+- Local `src/loader-shared` and default `src/main` are overlaid with shared/platform Java/resources from `../TomsStorage-1204`. That no-hyphen sibling is absent in this checkout, so inherited code is omitted and validation is blocked.
+- Run commands here: `bash gradlew tasks` to identify renamed run tasks and `bash gradlew build` only after verifying every source-set path exists. Do not create symlinks or rewrite paths unless requested.
+- Omitting JVM property `-DuseLib` excludes inherited `rei`; `emi` is always excluded. Any present `-DuseLib` value enables REI/Cloth/Architectury; JEI remains included.
+- Strongest validation is a source-path audit, `bash gradlew build`, then affected client and dedicated-server smoke tests. A build omitting absent shared/platform sources is not evidence.
+- Preserve Forge 1.20.4 mappings and NBT-era contracts. Metadata currently uses broad lower bounds (`Forge 48`, Minecraft `1.20.2`); do not copy or broaden them without deliberate compatibility validation.

--- a/Toms-Storage-LexForge-1204/src/loader-shared/java/AGENTS.md
+++ b/Toms-Storage-LexForge-1204/src/loader-shared/java/AGENTS.md
@@ -1,0 +1,7 @@
+# Legacy Forge-Shared Java Layer
+
+This local layer owns Minecraft 1.20.4 Forge lifecycle, configuration, capabilities, block entities, storage wrappers, tags, models, and packets.
+
+- Forge 1.20.4 APIs are allowed; NeoForge and Fabric APIs are not. Keep final adapters in `src/main/java`; intended loader-neutral and mapped platform behavior belongs to the configured sibling source owner.
+- Compare Forge 1.20.1 and NeoForge 1.20.4 counterparts before adapting signatures. The configured shared/platform sibling is absent, so compilation cannot validate their contracts here.
+- Preserve capability simulation, scan limits, loaded-chunk checks, NBT persistence, optional integration isolation, and dedicated-server safety.

--- a/Toms-Storage-LexForge-1204/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
+++ b/Toms-Storage-LexForge-1204/src/loader-shared/java/com/tom/storagemod/block/AGENTS.md
@@ -1,0 +1,7 @@
+# Legacy Forge Blocks
+
+Own Forge 1.20.4 proxy and framed cable block behavior layered over intended shared blocks.
+
+- Preserve capability exposure, framing/painting state, cable connectivity, drops, and recursive-network protection.
+- Inspect local `tile`/`util`, final platform registration, Forge 1.20.1 and NeoForge 1.20.4 block counterparts, and synchronized resources once the sibling composition exists.
+- Validate placement/removal, framed appearance, proxy recursion, capability access on each face, drops, and dedicated-server loading.

--- a/Toms-Storage-LexForge-1204/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
+++ b/Toms-Storage-LexForge-1204/src/loader-shared/java/com/tom/storagemod/model/AGENTS.md
@@ -1,0 +1,7 @@
+# Legacy Forge Models
+
+Own Forge 1.20.4 baked-model behavior for painted blocks.
+
+- Keep rendering client-only and preserve model data, tint, particle, transform, and fallback behavior without dedicated-server class-loading leaks.
+- Inspect `StorageModClient`, local painted block entities, loader resource models/states, and Forge 1.20.1 plus NeoForge 1.20.4 model counterparts.
+- Validate painted variants in world/inventory, resource reload, missing-model logs, and dedicated-server startup.

--- a/Toms-Storage-LexForge-1204/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
+++ b/Toms-Storage-LexForge-1204/src/loader-shared/java/com/tom/storagemod/network/AGENTS.md
@@ -1,0 +1,7 @@
+# Legacy Forge-Shared Network
+
+Own the Forge 1.20.4 wireless terminal open request consumed by the final channel.
+
+- Treat requests as untrusted and verify player, item/binding, range, dimension, config, and optional Curios location on the server.
+- Inspect final `network`, terminal block entities, config, intended shared wireless items, and Forge 1.20.1 plus NeoForge 1.20.4 counterparts.
+- Validate inventory and Curios keys, invalid binding, range/dimension denial, absent Curios, and dedicated-server handling.

--- a/Toms-Storage-LexForge-1204/src/loader-shared/java/com/tom/storagemod/rei/AGENTS.md
+++ b/Toms-Storage-LexForge-1204/src/loader-shared/java/com/tom/storagemod/rei/AGENTS.md
@@ -1,0 +1,7 @@
+# Legacy Forge REI Bridge
+
+Own the Forge 1.20.4 REI bridge compiled only when `-DuseLib` is present.
+
+- Keep package paths aligned with the Gradle exclusion and intended shared `rei`; no core path may load REI classes when absent.
+- Inspect `StorageModClient`, Gradle optional dependencies, Forge 1.20.1 and NeoForge 1.20.4 REI counterparts, and inherited shared handlers once available.
+- Validate default and `-DuseLib=true` builds, plugin discovery, transfer behavior, and dedicated-server startup without REI.

--- a/Toms-Storage-LexForge-1204/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
+++ b/Toms-Storage-LexForge-1204/src/loader-shared/java/com/tom/storagemod/tile/AGENTS.md
@@ -1,0 +1,7 @@
+# Legacy Forge Block Entities
+
+Own Forge 1.20.4 connector scans, storage aggregation, terminals, crafting, hoppers, emitters, proxies, painting, and connector state.
+
+- Preserve capability simulation/remainders, cycle/depth guards, 20-tick scans, loaded-chunk checks, NBT keys, and server authority; duplication or deletion is the highest risk.
+- Inspect local `util`/`block`, final `platform`/`network`, and matching Forge 1.20.1 plus NeoForge 1.20.4 block entities and menus.
+- Validate partial/full transfers, filters/priorities, nested handlers, disconnects, wireless access, save/reload, and unloaded endpoints after source composition is valid.

--- a/Toms-Storage-LexForge-1204/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
+++ b/Toms-Storage-LexForge-1204/src/loader-shared/java/com/tom/storagemod/util/AGENTS.md
@@ -1,0 +1,7 @@
+# Legacy Forge Storage Utilities
+
+Own Forge 1.20.4 `IItemHandler` aggregation/filtering, registration wrappers, remote links, filters, and inventory-link contracts.
+
+- Preserve simulation/remainders, handler ordering, cycle detection, `toms_storage_rc`, owner/visibility fields, and in-memory loaded-position caching without forced chunk loads.
+- Inspect local `tile`, final `platform`, intended shared items/utilities, and Forge 1.20.1 plus NeoForge 1.20.4 counterparts before changing interfaces.
+- Validate partial handlers, priorities, recursion, endpoint unload/reload, world save/reload, channel permissions, and missing endpoints.

--- a/Toms-Storage-LexForge-1204/src/loader-shared/resources/AGENTS.md
+++ b/Toms-Storage-LexForge-1204/src/loader-shared/resources/AGENTS.md
@@ -1,0 +1,7 @@
+# Legacy Forge-Shared Resources
+
+Own local Forge 1.20.4 overlays: framed/painted states, recipes/tags, and Curios slot/entity data.
+
+- Preserve namespaces and IDs; synchronize resources with local registrations/block entities and intended inherited blocks/items/assets without inventing replacements for absent shared resources.
+- Coordinate recipes with registry IDs/tags, Curios data with wireless lookup, and painted states with model registration.
+- After restoring source composition, validate resource logs, recipes, tags/mining, Curios access, painted rendering, and dedicated-server data loading.

--- a/Toms-Storage-LexForge-1204/src/main/java/AGENTS.md
+++ b/Toms-Storage-LexForge-1204/src/main/java/AGENTS.md
@@ -1,0 +1,7 @@
+# Final Legacy Forge Java Layer
+
+This layer owns final Minecraft 1.20.4 Forge channel and platform adapters; gameplay and mapped common code are intended to arrive from sibling overlays.
+
+- Forge 1.20.4 APIs are allowed; NeoForge and Fabric APIs are not. Do not duplicate shared behavior locally to mask the absent sibling path.
+- Inspect local loader-shared contracts and Forge 1.20.1 plus NeoForge 1.20.4 final adapters before changing implementations.
+- Preserve packet discriminators, registry IDs, capability semantics, mapped signatures, and client/server class separation.

--- a/Toms-Storage-LexForge-1204/src/main/java/com/tom/storagemod/network/AGENTS.md
+++ b/Toms-Storage-LexForge-1204/src/main/java/com/tom/storagemod/network/AGENTS.md
@@ -1,0 +1,7 @@
+# Legacy Forge Network Adapter
+
+Own the Forge 1.20.4 `SimpleChannel`, packet registration, `DataPacket` serialization, and server dispatch.
+
+- Preserve channel ID/version, discriminator order, compact NBT keys, direction/enqueue behavior, active-menu checks, and server authority.
+- Inspect local `OpenTerminalPacket`, intended inherited menus/receivers, and Forge 1.20.1 plus NeoForge 1.20.4 network adapters.
+- After restoring valid sources, validate malformed/stale packets, terminal/crafting actions, wireless opening, client/server compatibility, and dedicated-server startup.

--- a/Toms-Storage-LexForge-1204/src/main/java/com/tom/storagemod/platform/AGENTS.md
+++ b/Toms-Storage-LexForge-1204/src/main/java/com/tom/storagemod/platform/AGENTS.md
@@ -1,0 +1,7 @@
+# Legacy Forge Platform Adapter
+
+Own Forge 1.20.4 registries, creative tab, capabilities, interactions, menus, screens, and final mapped platform behavior.
+
+- Preserve registry IDs, registration timing, capability invalidation, interaction results, menu payloads, and sided class loading.
+- Inspect local loader-shared code, intended inherited `Content`/platform helpers/resources, and Forge 1.20.1 plus NeoForge 1.20.4 adapters; adapt mappings deliberately.
+- After restoring valid sources, validate registration, creative entries, menu/screen opening, capabilities, interactions, and client plus dedicated-server launch.

--- a/Toms-Storage-LexForge-1204/src/main/resources/AGENTS.md
+++ b/Toms-Storage-LexForge-1204/src/main/resources/AGENTS.md
@@ -1,0 +1,7 @@
+# Legacy Forge 1.20.4 Resources
+
+Own local `pack.mcmeta`, Forge metadata, and access-transformer inputs; common assets/data are intended to come from the absent configured sibling.
+
+- Keep exact Forge 1.20.4 mapped transformer signatures and mod ID stable. Treat current broad Forge 48/Minecraft 1.20.2 lower bounds as deliberate compatibility metadata requiring validation, not copyable defaults.
+- Synchronize metadata and transformer changes with Java call sites and packaged inherited resources once composition is valid; do not add guides inside `META-INF`.
+- Validate source paths first, then `bash gradlew build`, packaged resources, client metadata loading, and dedicated-server transformer behavior.


### PR DESCRIPTION
## Summary
- document the repository-wide multi-version and multi-loader architecture
- add scoped AGENTS.md guidance for every semantic project, source layer, functional package, and resource layer
- record source composition blockers, compatibility contracts, safety hotspots, and target-specific validation commands

## Validation
- independently audited all 148 AGENTS.md files and semantic coverage
- verified no trailing whitespace or non-ASCII content
- verified all Gradle wrapper commands use `bash gradlew` because wrappers are not executable
- no Gradle build run; documentation-only change, with existing sibling source-path blockers documented