### PR TITLE
Fix Crafting Terminal recipe book and controller-driven storage clicks

### DIFF
--- a/NeoForge/build.gradle
+++ b/NeoForge/build.gradle
@@ -117,6 +117,7 @@ sourceSets {
 	}
 }
 
+// Exclude duplicate resource tags (e.g. data/curios/tags/item/belt.json) across platform-shared and main resources
 tasks.withType(Copy).configureEach {
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/NeoForge/build.gradle
+++ b/NeoForge/build.gradle
@@ -103,6 +103,7 @@ sourceSets.main.resources { srcDir 'src/generated/resources' }
 sourceSets {
 	main {
 		java {
+			srcDir "src/main/java"
 			srcDir "src/platform-shared/java"
 			//if(!useLib)exclude "com/tom/storagemod/rei/**"
 			//if(!useLib)exclude "com/tom/storagemod/jei/**"
@@ -110,9 +111,17 @@ sourceSets {
 			//if(!useLib)exclude "com/tom/storagemod/top/**"
 		}
 		resources {
+			srcDir "src/main/resources"
 			srcDir "src/platform-shared/resources"
 		}
 	}
+}
+
+tasks.withType(Copy).configureEach {
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+tasks.withType(Jar).configureEach {
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 dependencies {

--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/block/entity/InventoryConnectorBlockEntity.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/block/entity/InventoryConnectorBlockEntity.java
@@ -40,6 +40,15 @@ public class InventoryConnectorBlockEntity extends PlatformBlockEntity implement
 	private Set<IInventoryConnector> linkedConnectors = new HashSet<>();
 	private Set<BlockFace> interfaces = new HashSet<>();
 
+	// Scratch buffers reused across detectTouchingInventories() calls to avoid reallocating
+	// collections every scan (every 20 ticks per connector).
+	private final Map<BlockPos, Direction> scanConnected = new HashMap<>();
+	private final Set<BlockFilter> scanBlockFilters = new HashSet<>();
+	private Set<BlockFace> scanInterfaces = new HashSet<>();
+	private final Stack<BlockPos> scanToCheck = new Stack<>();
+	private final Set<BlockPos> scanCheckedBlocks = new HashSet<>();
+	private Map<BlockFace, BlockInventoryAccess> scanInvA = new HashMap<>();
+
 	public InventoryConnectorBlockEntity(BlockPos p_155229_, BlockState p_155230_) {
 		super(Content.connectorBE.get(), p_155229_, p_155230_);
 	}
@@ -73,12 +82,17 @@ public class InventoryConnectorBlockEntity extends PlatformBlockEntity implement
 		UnaryOperator<IInventoryAccess> wrapper = connFilter != null ? i -> connFilter.wrap(level, i) : UnaryOperator.identity();
 
 		connectedInvs.clear();
-		Map<BlockPos, Direction> connected = new HashMap<>();
-		Set<BlockFilter> blockFilters = new HashSet<>();
-		Set<BlockFace> interfaces = new HashSet<>();
+		Map<BlockPos, Direction> connected = scanConnected;
+		Set<BlockFilter> blockFilters = scanBlockFilters;
+		Set<BlockFace> interfaces = scanInterfaces;
+		connected.clear();
+		blockFilters.clear();
+		interfaces.clear();
 
-		Stack<BlockPos> toCheck = new Stack<>();
-		Set<BlockPos> checkedBlocks = new HashSet<>();
+		Stack<BlockPos> toCheck = scanToCheck;
+		Set<BlockPos> checkedBlocks = scanCheckedBlocks;
+		toCheck.clear();
+		checkedBlocks.clear();
 		toCheck.add(worldPosition);
 		checkedBlocks.add(worldPosition);
 		int maxRange = Config.get().invConnectorScanRange;
@@ -118,7 +132,8 @@ public class InventoryConnectorBlockEntity extends PlatformBlockEntity implement
 
 		blockFilters.forEach(f -> f.getConnectedBlocks().forEach(connected::remove));
 
-		Map<BlockFace, BlockInventoryAccess> invA = new HashMap<>();
+		Map<BlockFace, BlockInventoryAccess> invA = scanInvA;
+		invA.clear();
 		connected.forEach((p, d) -> {
 			BlockFace s = new BlockFace(p, d);
 			BlockInventoryAccess acc = invAccesses.remove(s);
@@ -142,11 +157,16 @@ public class InventoryConnectorBlockEntity extends PlatformBlockEntity implement
 		});
 		invAccesses.values().forEach(IInventoryAccess::markInvalid);
 		invAccesses.clear();
+		// Swap the now-empty invAccesses map into the scratch slot for reuse next scan,
+		// instead of allocating a fresh map every 20 ticks.
+		scanInvA = invAccesses;
 		invAccesses = invA;
 
 		if (!this.interfaces.equals(interfaces)) {
 			var net = InventoryCableNetwork.getNetwork(level);
 			this.interfaces.forEach(net::markNodeInvalid);
+			// Swap the old interfaces set into the scratch slot for reuse next scan.
+			scanInterfaces = this.interfaces;
 			this.interfaces = interfaces;
 			net.markNodeInvalid(worldPosition);
 		}

--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/block/entity/StorageTerminalBlockEntity.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/block/entity/StorageTerminalBlockEntity.java
@@ -40,6 +40,10 @@ import com.tom.storagemod.util.TickerUtil.TickableServer;
 import com.tom.storagemod.util.Util;
 
 public class StorageTerminalBlockEntity extends PlatformBlockEntity implements MenuProvider, TickableServer {
+	private static final int PASSIVE_REFRESH_INTERVAL_TICKS = 20;
+	private static final int BEACON_SCAN_INTERVAL_TICKS = 40;
+	private static final int BEACON_SCAN_RADIUS = 8;
+
 	private NetworkInventory itemCache = new NetworkInventory();
 	private Map<StoredItemStack, TerminalItemStack> items = new HashMap<>();
 	private int sort;
@@ -146,9 +150,12 @@ public class StorageTerminalBlockEntity extends PlatformBlockEntity implements M
 
 	@Override
 	public void updateServer() {
-		refreshItems();
-		if(level.getGameTime() % 40 == Math.abs(worldPosition.hashCode()) % 40) {
-			beaconLevel = BlockPos.betweenClosedStream(new AABB(worldPosition).inflate(8)).mapToInt(p -> {
+		// Passive keep-warm; getStacks() already forces a fresh refresh on every real read.
+		if(level.getGameTime() % PASSIVE_REFRESH_INTERVAL_TICKS == Math.abs(worldPosition.hashCode()) % PASSIVE_REFRESH_INTERVAL_TICKS) {
+			refreshItems();
+		}
+		if(level.getGameTime() % BEACON_SCAN_INTERVAL_TICKS == Math.abs(worldPosition.hashCode()) % BEACON_SCAN_INTERVAL_TICKS) {
+			beaconLevel = BlockPos.betweenClosedStream(new AABB(worldPosition).inflate(BEACON_SCAN_RADIUS)).mapToInt(p -> {
 				if(level.isLoaded(p)) {
 					BlockState st = level.getBlockState(p);
 					if(st.is(Blocks.BEACON)) {

--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/block/entity/StorageTerminalBlockEntity.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/block/entity/StorageTerminalBlockEntity.java
@@ -46,7 +46,6 @@ public class StorageTerminalBlockEntity extends PlatformBlockEntity implements M
 	private int searchType;
 	private int modes;
 	private String lastSearch = "";
-	private boolean updateItems;
 	private int changeCount;
 	private int beaconLevel;
 	private long changeTracker;
@@ -84,7 +83,7 @@ public class StorageTerminalBlockEntity extends PlatformBlockEntity implements M
 	}
 
 	public Map<StoredItemStack, TerminalItemStack> getStacks() {
-		updateItems = true;
+		refreshItems();
 		return items;
 	}
 
@@ -121,30 +120,33 @@ public class StorageTerminalBlockEntity extends PlatformBlockEntity implements M
 		Containers.dropItemStack(level, worldPosition.getX() + .5f, worldPosition.getY() + .5f, worldPosition.getZ() + .5f, stack);
 	}
 
+	// Shared by the tick loop and getStacks() so callers always get current counts, not a
+	// tick-old snapshot. changeTracker still skips the rescan when nothing changed.
+	private void refreshItems() {
+		IInventoryAccess ii = itemCache.getAccess(level, worldPosition);
+		IInventoryChangeTracker tr = ii.tracker();
+		long ct = tr.getChangeTracker(level);
+		if (changeTracker != ct) {
+			changeTracker = ct;
+
+			if (Config.get().runMultithreaded) {
+				items = tr.streamWrappedStacks(true).map(TerminalItemStack::new)
+						.collect(Collectors.groupingBy(Function.identity(), Util.reducingWithCopy(null, TerminalItemStack::merge, TerminalItemStack::new)));
+			} else {
+				items = new HashMap<>();
+				tr.streamWrappedStacks(false).map(TerminalItemStack::new)
+				.forEach(s -> items.merge(s, s, TerminalItemStack::merge));
+				items.replaceAll((k, v) -> new TerminalItemStack(v));
+			}
+			slotCount = Mth.clamp(ii.getSlotCount(), 0, Short.MAX_VALUE);
+			freeCount = Mth.clamp(ii.getFreeSlotCount(), 0, Short.MAX_VALUE);
+			changeCount++;
+		}
+	}
+
 	@Override
 	public void updateServer() {
-		if(updateItems) {
-			IInventoryAccess ii = itemCache.getAccess(level, worldPosition);
-			IInventoryChangeTracker tr = ii.tracker();
-			long ct = tr.getChangeTracker(level);
-			if (changeTracker != ct) {
-				changeTracker = ct;
-
-				if (Config.get().runMultithreaded) {
-					items = tr.streamWrappedStacks(true).map(TerminalItemStack::new)
-							.collect(Collectors.groupingBy(Function.identity(), Util.reducingWithCopy(null, TerminalItemStack::merge, TerminalItemStack::new)));
-				} else {
-					items = new HashMap<>();
-					tr.streamWrappedStacks(false).map(TerminalItemStack::new)
-					.forEach(s -> items.merge(s, s, TerminalItemStack::merge));
-					items.replaceAll((k, v) -> new TerminalItemStack(v));
-				}
-				slotCount = Mth.clamp(ii.getSlotCount(), 0, Short.MAX_VALUE);
-				freeCount = Mth.clamp(ii.getFreeSlotCount(), 0, Short.MAX_VALUE);
-				changeCount++;
-			}
-			updateItems = false;
-		}
+		refreshItems();
 		if(level.getGameTime() % 40 == Math.abs(worldPosition.hashCode()) % 40) {
 			beaconLevel = BlockPos.betweenClosedStream(new AABB(worldPosition).inflate(8)).mapToInt(p -> {
 				if(level.isLoaded(p)) {

--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/menu/CraftingTerminalMenu.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/menu/CraftingTerminalMenu.java
@@ -29,6 +29,7 @@ import com.tom.storagemod.inventory.TerminalItemStack;
 import com.tom.storagemod.platform.NeoForgeMenu;
 import com.tom.storagemod.util.IAutoFillTerminal;
 import com.tom.storagemod.util.IDataReceiver;
+import com.tom.storagemod.util.TerminalSyncManager;
 
 public class CraftingTerminalMenu extends StorageTerminalMenu implements IAutoFillTerminal, IDataReceiver, NeoForgeMenu {
 	public static class SlotCrafting extends Slot {
@@ -196,7 +197,7 @@ public class CraftingTerminalMenu extends StorageTerminalMenu implements IAutoFi
 					// getStack() always has count 1 - give accountStack a copy with the real
 					// quantity, otherwise it clamps everything down to 1.
 					ItemStack stack = c.getStack().copy();
-					stack.setCount((int) Math.min(c.getQuantity(), 65536));
+					stack.setCount((int) Math.min(c.getQuantity(), TerminalSyncManager.MAX_ACCOUNTED_STACK_SIZE));
 					itemHelperIn.accountStack(stack, stack.getCount());
 				}
 			});
@@ -204,7 +205,7 @@ public class CraftingTerminalMenu extends StorageTerminalMenu implements IAutoFi
 			itemList.forEach(e -> {
 				if (e.getQuantity() > 0) {
 					ItemStack stack = e.getStack().copy();
-					stack.setCount((int) Math.min(e.getQuantity(), 65536));
+					stack.setCount((int) Math.min(e.getQuantity(), TerminalSyncManager.MAX_ACCOUNTED_STACK_SIZE));
 					itemHelperIn.accountStack(stack, stack.getCount());
 				}
 			});

--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/menu/CraftingTerminalMenu.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/menu/CraftingTerminalMenu.java
@@ -59,6 +59,7 @@ public class CraftingTerminalMenu extends StorageTerminalMenu implements IAutoFi
 		craftMatrix = te.getCraftingInv();
 		craftResult = te.getCraftResult();
 		init();
+		addStorageSlots(5, 8, 18);
 		this.addPlayerSlots(inv, 8, 174);
 		te.registerCrafting(this);
 	}
@@ -68,6 +69,7 @@ public class CraftingTerminalMenu extends StorageTerminalMenu implements IAutoFi
 		craftMatrix = new TransientCraftingContainer(this, 3, 3);
 		craftResult = new ResultContainer();
 		init();
+		addStorageSlots(5, 8, 18);
 		this.addPlayerSlots(inv, 8, 174);
 	}
 
@@ -107,7 +109,8 @@ public class CraftingTerminalMenu extends StorageTerminalMenu implements IAutoFi
 
 	@Override
 	protected void addStorageSlots() {
-		addStorageSlots(5, 8, 18);
+		// No-op: storage slots are added explicitly after init() in the constructors below,
+		// so the crafting result/grid keep slots 0..9 (required by the recipe book).
 	}
 
 	@Override
@@ -125,7 +128,7 @@ public class CraftingTerminalMenu extends StorageTerminalMenu implements IAutoFi
 			if (index == 0) {
 				if(te == null)return ItemStack.EMPTY;
 
-				if (!((CraftingTerminalBlockEntity)te).canCraft() || !this.moveItemStackTo(itemstack1, 10, 46, true)) {
+				if (!((CraftingTerminalBlockEntity)te).canCraft() || !this.moveItemStackTo(itemstack1, playerSlotsStart + 1, playerSlotsStart + 1 + 36, true)) {
 					return ItemStack.EMPTY;
 				}
 
@@ -186,10 +189,26 @@ public class CraftingTerminalMenu extends StorageTerminalMenu implements IAutoFi
 	@Override
 	public void fillCraftSlotsStackedContents(StackedContents itemHelperIn) {
 		this.craftMatrix.fillStackedContents(itemHelperIn);
-		if(te != null)sync.fillStackedContents(itemHelperIn);
-		else itemList.forEach(e -> {
-			itemHelperIn.accountSimpleStack(e.getActualStack());
-		});
+		if(te != null) {
+			te.getStacks().forEach((s, c) -> {
+				// c (the value) holds the merged quantity; s (the key) may be stale.
+				if (c.getQuantity() > 0) {
+					// getStack() always has count 1 - give accountStack a copy with the real
+					// quantity, otherwise it clamps everything down to 1.
+					ItemStack stack = c.getStack().copy();
+					stack.setCount((int) Math.min(c.getQuantity(), 65536));
+					itemHelperIn.accountStack(stack, stack.getCount());
+				}
+			});
+		} else {
+			itemList.forEach(e -> {
+				if (e.getQuantity() > 0) {
+					ItemStack stack = e.getStack().copy();
+					stack.setCount((int) Math.min(e.getQuantity(), 65536));
+					itemHelperIn.accountStack(stack, stack.getCount());
+				}
+			});
+		}
 	}
 
 	@Override

--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/menu/StorageTerminalMenu.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/menu/StorageTerminalMenu.java
@@ -311,7 +311,9 @@ public class StorageTerminalMenu extends RecipeBookMenu<CraftingInput, CraftingR
 				}
 
 				if (action != null) {
-					sync.sendInteract(slotStorage.stack, action, mod);
+					if (slotStorage.stack != null || !getCarried().isEmpty()) {
+						sync.sendInteract(slotStorage.stack, action, mod);
+					}
 				}
 			}
 			return;
@@ -334,7 +336,9 @@ public class StorageTerminalMenu extends RecipeBookMenu<CraftingInput, CraftingR
 				}
 			} else if (index >= 0 && index < slots.size() && slots.get(index) instanceof SlotStorage slotStorage) {
 				if (playerIn.level().isClientSide) {
-					sync.sendInteract(slotStorage.stack, SlotAction.SHIFT_PULL, false);
+					if (slotStorage.stack != null && slotStorage.stack.getQuantity() > 0) {
+						sync.sendInteract(slotStorage.stack, SlotAction.SHIFT_PULL, false);
+					}
 				}
 			} else {
 				return shiftClickItems(playerIn, index);

--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/menu/StorageTerminalMenu.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/menu/StorageTerminalMenu.java
@@ -11,6 +11,7 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.player.StackedContents;
+import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.RecipeBookMenu;
@@ -142,9 +143,11 @@ public class StorageTerminalMenu extends RecipeBookMenu<CraftingInput, CraftingR
 
 	protected final void addSlotToContainer(SlotStorage slotStorage) {
 		storageSlotList.add(slotStorage);
+		this.addSlot(slotStorage);
 	}
 
-	public static class SlotStorage {
+	public static class SlotStorage extends Slot {
+		private static final net.minecraft.world.Container DUMMY_CONTAINER = new net.minecraft.world.SimpleContainer(0);
 		/** display position of the inventory slot on the screen x axis */
 		public int xDisplayPosition;
 		/** display position of the inventory slot on the screen y axis */
@@ -156,10 +159,51 @@ public class StorageTerminalMenu extends RecipeBookMenu<CraftingInput, CraftingR
 		public TerminalItemStack stack;
 
 		public SlotStorage(StorageTerminalBlockEntity inventory, int slotIndex, int xPosition, int yPosition) {
+			super(DUMMY_CONTAINER, slotIndex, xPosition, yPosition);
 			this.xDisplayPosition = xPosition;
 			this.yDisplayPosition = yPosition;
 			this.slotIndex = slotIndex;
 			this.inventory = inventory;
+		}
+
+		@Override
+		public ItemStack getItem() {
+			return stack != null ? stack.getStack() : ItemStack.EMPTY;
+		}
+
+		@Override
+		public void set(ItemStack stack) {
+			// Virtual slot; do not modify DUMMY_CONTAINER
+		}
+
+		@Override
+		public void setByPlayer(ItemStack stack, ItemStack previousStack) {
+			// Virtual slot; do not modify DUMMY_CONTAINER
+		}
+
+		@Override
+		public int getMaxStackSize() {
+			return Integer.MAX_VALUE;
+		}
+
+		@Override
+		public int getMaxStackSize(ItemStack stack) {
+			return Integer.MAX_VALUE;
+		}
+
+		@Override
+		public void setChanged() {
+			// Virtual slot
+		}
+
+		@Override
+		public boolean mayPickup(Player playerIn) {
+			return stack != null && stack.getQuantity() > 0;
+		}
+
+		@Override
+		public boolean mayPlace(ItemStack stack) {
+			return true;
 		}
 
 		public ItemStack pullFromSlot(long max) {
@@ -248,6 +292,34 @@ public class StorageTerminalMenu extends RecipeBookMenu<CraftingInput, CraftingR
 	}
 
 	@Override
+	public void clicked(int slotId, int button, ClickType clickType, Player player) {
+		if (slotId >= 0 && slotId < slots.size() && slots.get(slotId) instanceof SlotStorage slotStorage) {
+			if (player.level().isClientSide) {
+				SlotAction action = null;
+				boolean mod = false;
+
+				if (clickType == ClickType.QUICK_MOVE) {
+					action = SlotAction.SHIFT_PULL;
+				} else if (clickType == ClickType.PICKUP) {
+					if (button == 0) {
+						action = SlotAction.PULL_OR_PUSH_STACK;
+					} else if (button == 1) {
+						action = getCarried().isEmpty() ? SlotAction.GET_HALF : SlotAction.PULL_ONE;
+					}
+				} else if (clickType == ClickType.CLONE) {
+					action = SlotAction.PULL_OR_PUSH_STACK;
+				}
+
+				if (action != null) {
+					sync.sendInteract(slotStorage.stack, action, mod);
+				}
+			}
+			return;
+		}
+		super.clicked(slotId, button, clickType, player);
+	}
+
+	@Override
 	public final ItemStack quickMoveStack(Player playerIn, int index) {
 		if (slots.size() > index) {
 			if (index > playerSlotsStart && te != null) {
@@ -259,6 +331,10 @@ public class StorageTerminalMenu extends RecipeBookMenu<CraftingInput, CraftingR
 					slot.set(itemstack);
 					if (!playerIn.level().isClientSide)
 						broadcastChanges();
+				}
+			} else if (index >= 0 && index < slots.size() && slots.get(index) instanceof SlotStorage slotStorage) {
+				if (playerIn.level().isClientSide) {
+					sync.sendInteract(slotStorage.stack, SlotAction.SHIFT_PULL, false);
 				}
 			} else {
 				return shiftClickItems(playerIn, index);

--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/menu/TerminalRecipePlacer.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/menu/TerminalRecipePlacer.java
@@ -17,6 +17,9 @@ import com.tom.storagemod.block.entity.CraftingTerminalBlockEntity;
 import com.tom.storagemod.inventory.StoredItemStack;
 
 class TerminalRecipePlacer extends ServerPlaceRecipe<CraftingInput, CraftingRecipe> {
+	// Slot 0 is the crafting result; the grid occupies the slots right after it.
+	private static final int GRID_SLOT_START = 1;
+
 	private CraftingTerminalBlockEntity te;
 	private Player player;
 
@@ -52,8 +55,9 @@ class TerminalRecipePlacer extends ServerPlaceRecipe<CraftingInput, CraftingReci
 		// Only clears if something actually changed, so an early return in the vanilla method
 		// (which can leave an unrelated, pre-existing grid untouched) doesn't wipe it.
 		int gridSize = this.menu.getGridWidth() * this.menu.getGridHeight();
+		int gridSlotEnd = GRID_SLOT_START + gridSize - 1;
 		List<ItemStack> before = new ArrayList<>(gridSize);
-		for (int i = 1; i <= gridSize; i++) {
+		for (int i = GRID_SLOT_START; i <= gridSlotEnd; i++) {
 			before.add(this.menu.getSlot(i).getItem().copy());
 		}
 
@@ -61,8 +65,8 @@ class TerminalRecipePlacer extends ServerPlaceRecipe<CraftingInput, CraftingReci
 
 		if (!this.menu.recipeMatches(recipe)) {
 			boolean changed = false;
-			for (int i = 1; i <= gridSize; i++) {
-				if (!ItemStack.matches(before.get(i - 1), this.menu.getSlot(i).getItem())) {
+			for (int i = GRID_SLOT_START; i <= gridSlotEnd; i++) {
+				if (!ItemStack.matches(before.get(i - GRID_SLOT_START), this.menu.getSlot(i).getItem())) {
 					changed = true;
 					break;
 				}

--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/menu/TerminalRecipePlacer.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/menu/TerminalRecipePlacer.java
@@ -1,11 +1,17 @@
 package com.tom.storagemod.menu;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.network.protocol.game.ClientboundPlaceGhostRecipePacket;
 import net.minecraft.recipebook.ServerPlaceRecipe;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import com.tom.storagemod.block.entity.CraftingTerminalBlockEntity;
 import com.tom.storagemod.inventory.StoredItemStack;
@@ -18,6 +24,53 @@ class TerminalRecipePlacer extends ServerPlaceRecipe<CraftingInput, CraftingReci
 		super(p_135431_);
 		this.te = te;
 		this.player = player;
+	}
+
+	@Override
+	public void recipeClicked(ServerPlayer player, RecipeHolder<CraftingRecipe> recipe, boolean placeAll) {
+		// Skips vanilla's testClearGrid() gate: it checks the player's real inventory, but
+		// clearGrid() below returns items to the storage network instead.
+		if (recipe != null && player.getRecipeBook().contains(recipe)) {
+			this.inventory = player.getInventory();
+			this.stackedContents.clear();
+			player.getInventory().fillStackedContents(this.stackedContents);
+			this.menu.fillCraftSlotsStackedContents(this.stackedContents);
+			if (this.stackedContents.canCraft(recipe.value(), null)) {
+				this.handleRecipeClicked(recipe, placeAll);
+			} else {
+				this.clearGrid();
+				player.connection.send(new ClientboundPlaceGhostRecipePacket(player.containerMenu.containerId, recipe));
+			}
+
+			player.getInventory().setChanged();
+		}
+	}
+
+	@Override
+	protected void handleRecipeClicked(RecipeHolder<CraftingRecipe> recipe, boolean placeAll) {
+		// Roll back a partial/failed placement instead of leaving broken contents in the grid.
+		// Only clears if something actually changed, so an early return in the vanilla method
+		// (which can leave an unrelated, pre-existing grid untouched) doesn't wipe it.
+		int gridSize = this.menu.getGridWidth() * this.menu.getGridHeight();
+		List<ItemStack> before = new ArrayList<>(gridSize);
+		for (int i = 1; i <= gridSize; i++) {
+			before.add(this.menu.getSlot(i).getItem().copy());
+		}
+
+		super.handleRecipeClicked(recipe, placeAll);
+
+		if (!this.menu.recipeMatches(recipe)) {
+			boolean changed = false;
+			for (int i = 1; i <= gridSize; i++) {
+				if (!ItemStack.matches(before.get(i - 1), this.menu.getSlot(i).getItem())) {
+					changed = true;
+					break;
+				}
+			}
+			if (changed) {
+				this.clearGrid();
+			}
+		}
 	}
 
 	@Override
@@ -47,7 +100,7 @@ class TerminalRecipePlacer extends ServerPlaceRecipe<CraftingInput, CraftingReci
 				} else {
 					slotToFill.getItem().grow(1);
 				}
-				return -1;
+				return count - 1;
 			}
 		}
 		return -1;

--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/screen/AbstractStorageTerminalScreen.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/screen/AbstractStorageTerminalScreen.java
@@ -207,7 +207,7 @@ public abstract class AbstractStorageTerminalScreen<T extends StorageTerminalMen
 		this.searchField.setTextColor(16777215);
 		this.searchField.setValue(searchLast);
 		searchLast = "";
-		addWidget(searchField);
+		addRenderableWidget(searchField);
 		buttonSortingType = addRenderableWidget(new EnumCycleButton<>(leftPos - 18, topPos + 5, Component.translatable("narrator.toms_storage.terminal_sort"), "sort", SortingTypes.VALUES, n -> {
 			sortingType = n;
 			buttonSortingType.setState(n);
@@ -547,6 +547,14 @@ public abstract class AbstractStorageTerminalScreen<T extends StorageTerminalMen
 	}
 
 	@Override
+	protected void renderSlot(GuiGraphics guiGraphics, Slot slot) {
+		if (slot instanceof StorageTerminalMenu.SlotStorage) {
+			return;
+		}
+		super.renderSlot(guiGraphics, slot);
+	}
+
+	@Override
 	public boolean mouseClicked(double mouseX, double mouseY, int mouseButton) {
 		if (popup.mouseClick(mouseX, mouseY, mouseButton))return true;
 		if (slotIDUnderMouse > -1) {
@@ -595,6 +603,16 @@ public abstract class AbstractStorageTerminalScreen<T extends StorageTerminalMen
 
 	protected void storageSlotClick(StoredItemStack slotStack, SlotAction act, boolean mod) {
 		menu.sync.sendInteract(slotStack, act, mod);
+	}
+
+	@Override
+	public boolean mouseReleased(double mouseX, double mouseY, int mouseButton) {
+		if (slotIDUnderMouse > -1) {
+			// Storage slots are handled entirely in mouseClicked; skip vanilla's release
+			// handling here or it re-triggers clicked() and pushes the just-pulled item back.
+			return true;
+		}
+		return super.mouseReleased(mouseX, mouseY, mouseButton);
 	}
 
 	public boolean isPullOne(int mouseButton) {

--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/screen/InventoryConfiguratorScreen.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/screen/InventoryConfiguratorScreen.java
@@ -83,6 +83,13 @@ public class InventoryConfiguratorScreen extends PlatformContainerScreen<Invento
 			click(7);
 		}));
 		buttonRemoveFilter.setTooltip(Tooltip.create(Component.translatable("tooltip.toms_storage.inv_config.remove_filter")));
+
+		// Set initial state here, not just in render(): narration can run right after init()
+		// and would otherwise see a null EnumCycleButton state.
+		buttonPriority.setState(menu.priority);
+		buttonSide.setState(menu.side);
+		buttonSkip.setState(menu.skip);
+		buttonKeepLast.setState(menu.keepLast);
 	}
 
 	@Override

--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/screen/widget/EnumCycleButton.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/screen/widget/EnumCycleButton.java
@@ -24,12 +24,15 @@ public class EnumCycleButton<T extends Enum<T>> extends IconButton {
 
 	@Override
 	protected MutableComponent createNarrationMessage() {
+		if (state == null) {
+			return wrapDefaultNarrationMessage(name.copy());
+		}
 		return wrapDefaultNarrationMessage(name.copy().append(" ").append(Component.translatable("narrator.toms_storage.button_state." + state.name().toLowerCase(Locale.ROOT))));
 	}
 
 	@Override
 	public ResourceLocation getIcon() {
-		return icon.apply(state);
+		return state == null ? null : icon.apply(state);
 	}
 
 	public void setState(T state) {

--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/screen/widget/IconButton.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/screen/widget/IconButton.java
@@ -47,7 +47,10 @@ public class IconButton extends Button {
 	}
 
 	protected void drawIcon(GuiGraphics st, int mouseX, int mouseY, float pt) {
-		st.blitSprite(getIcon(), this.getX(), this.getY(), this.getWidth(), this.getHeight());
+		ResourceLocation iconLoc = getIcon();
+		if (iconLoc != null) {
+			st.blitSprite(iconLoc, this.getX(), this.getY(), this.getWidth(), this.getHeight());
+		}
 	}
 
 	public ResourceLocation getIcon() {

--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/util/TerminalSyncManager.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/util/TerminalSyncManager.java
@@ -33,6 +33,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
 public class TerminalSyncManager {
 	private static final int MAX_PACKET_SIZE = 64000;
+	public static final int MAX_ACCOUNTED_STACK_SIZE = 65536;
 	private Object2IntMap<StoredItemStack> idMap = new Object2IntOpenHashMap<>();
 	private Int2ObjectMap<StoredItemStack> idMap2 = new Int2ObjectArrayMap<>();
 	private Map<StoredItemStack, TerminalItemStack> items = new HashMap<>();
@@ -241,7 +242,7 @@ public class TerminalSyncManager {
 				// getStack() always has count 1 - give accountStack a copy with the real
 				// quantity, otherwise it clamps everything down to 1.
 				ItemStack stack = c.getStack().copy();
-				stack.setCount((int) Math.min(c.getQuantity(), 65536));
+				stack.setCount((int) Math.min(c.getQuantity(), MAX_ACCOUNTED_STACK_SIZE));
 				stc.accountStack(stack, stack.getCount());
 			}
 		});

--- a/NeoForge/src/platform-shared/java/com/tom/storagemod/util/TerminalSyncManager.java
+++ b/NeoForge/src/platform-shared/java/com/tom/storagemod/util/TerminalSyncManager.java
@@ -236,7 +236,15 @@ public class TerminalSyncManager {
 	}
 
 	public void fillStackedContents(StackedContents stc) {
-		items.forEach((s, c) -> stc.accountSimpleStack(c.getActualStack()));
+		itemList.values().forEach(c -> {
+			if (c.getQuantity() > 0) {
+				// getStack() always has count 1 - give accountStack a copy with the real
+				// quantity, otherwise it clamps everything down to 1.
+				ItemStack stack = c.getStack().copy();
+				stack.setCount((int) Math.min(c.getQuantity(), 65536));
+				stc.accountStack(stack, stack.getCount());
+			}
+		});
 	}
 
 	public long getAmount(StoredItemStack stack) {


### PR DESCRIPTION
## Summary

Several fixes to the Crafting Terminal's recipe book integration and to storage-slot interaction, found while adding controller (Controlify) support to the storage terminal slots.

### Recipe book / crafting grid

- **Slot order regression**: making the storage list slots real registered `Slot`s (needed for controller cursor navigation) caused them to be added to the menu's slot list *before* the crafting result/grid slots. The vanilla recipe book (`ServerPlaceRecipe`/`PlaceRecipe`) assumes the result slot is index `0` and the grid is `1..9`. With storage slots first, missing-ingredient ghost highlights and placed ingredients landed on the storage list instead of the crafting grid, and items could silently vanish (pulled from storage/inventory but "placed" into a slot whose `set()` is a no-op).
  - Fix: register storage slots explicitly after the crafting slots, and fix a related hardcoded slot range in `shiftClickItems` that assumed the old ordering.
- **`moveItemToGrid` sentinel bug**: the "ingredient not found anywhere" case returned the unchanged remaining count instead of `-1`, which is the sentinel the calling loop in vanilla `PlaceRecipe.addItemToSlot` checks for to stop. Returning anything else lets that loop spin forever.
- **`testClearGrid()` gate**: vanilla gates the whole recipe click on whether the grid's current contents fit back into the player's *inventory*. The Crafting Terminal returns items to the storage network instead (falling back to inventory, then dropping on the ground), so that check no longer applies and was making recipes look randomly unresponsive when the player's inventory happened to be full.
- **Partial-fill rollback**: if the ingredient snapshot used for the availability check and the live pull disagree (e.g. items moved between the two), part of a recipe could get placed while the rest fails, leaving a broken half-filled grid. Now rolls the whole attempt back - but only if something was actually placed, so clicking an unrelated unavailable recipe doesn't wipe unrelated content already sitting in the grid.
- **Quantity accounting bug**: `fillCraftSlotsStackedContents` fed `StackedContents.accountStack` an `ItemStack` whose internal count is always normalized to `1` (the real quantity is tracked separately). Vanilla's `accountStack` clamps to `Math.min(maxAmount, stack.getCount())`, so every item was accounted as exactly `1` regardless of how many were actually stored - recipes needing more than 1 of a stored ingredient were never craftable from network storage. Also fixed reading the quantity from the map value instead of the (possibly stale) key after merging same-item stacks from multiple containers.
- **Stale item counts**: `getStacks()` only flagged a refresh for the next tick instead of refreshing immediately, so availability checks could read a tick-old snapshot of network storage.

### Storage terminal clicks

- Making storage slots real `Slot`s also meant vanilla's `mouseReleased` "place carried item into hovered slot" fallback now finds them. Since our click handling already resolved the pickup by the time of release, this re-triggered a click that immediately pushed the just-pulled item back into storage. Storage slot interaction is now fully opted out of that vanilla fallback.

### Inventory Configurator

- Opening the Inventory Configurator via a controller disconnected with an NPE in `EnumCycleButton.createNarrationMessage`. Controlify triggers immediate screen narration on controller-driven screen opens, which runs right after `init()` and before the first `render()` - but `EnumCycleButton`'s state was only ever set in `render()`, so narration saw a null state. Now set during `init()` as well, with a defensive null-check added to the widget itself.

### Build

- `src/main/java`/`src/main/resources` weren't included in the NeoForge source set, which broke resolution of classes under `src/main` (e.g. `WorldStates`).

## Test plan

- Manually tested in a NeoForge 1.21.1 dev environment with Controlify installed:
  - Opened the recipe book in the Crafting Terminal, clicked recipes sourced from player inventory, from network storage, and from a mix of both.
  - Verified missing-ingredient highlighting appears on the crafting grid, not the storage list.
  - Verified switching between an available and an unavailable recipe doesn't destroy in-progress grid contents.
  - Verified storage list items can be picked up with the mouse without being pushed back immediately.
  - Opened the Inventory Configurator via mouse and via controller; controller open no longer disconnects.
  
  
  Issues: #689